### PR TITLE
create tekton operator subscription

### DIFF
--- a/pkg/apis/toolchain/v1alpha1/conditions.go
+++ b/pkg/apis/toolchain/v1alpha1/conditions.go
@@ -7,16 +7,12 @@ import (
 
 const (
 	// status condition type
-	CheReady       toolchainv1alpha1.ConditionType = "CheReady"
-	CheNotReady    toolchainv1alpha1.ConditionType = "CheNotReady"
-	TektonReady    toolchainv1alpha1.ConditionType = "TektonReady"
-	TektonNotReady toolchainv1alpha1.ConditionType = "TektonNotReady"
+	CheReady    toolchainv1alpha1.ConditionType = "CheReady"
+	TektonReady toolchainv1alpha1.ConditionType = "TektonReady"
 
 	// Status condition reasons
-	FailedToCreateCheSubscriptionReason    = "FailedToCreateCheSubscription"
-	FailedToCreateTektonSubscriptionReason = "FailedToCreateTektonSubscription"
-	CreatedCheSubscriptionReason           = "CreatedCheSubscription"
-	CreatedTektonSubscriptionReason        = "CreatedTektonSubscription"
+	FailedToInstallReason = "FailedToInstall"
+	InstalledReason       = "Installed"
 )
 
 func SubscriptionCreated(conditionType toolchainv1alpha1.ConditionType, reason, message string) toolchainv1alpha1.Condition {

--- a/pkg/apis/toolchain/v1alpha1/conditions.go
+++ b/pkg/apis/toolchain/v1alpha1/conditions.go
@@ -1,0 +1,38 @@
+package v1alpha1
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// status condition type
+	CheReady       toolchainv1alpha1.ConditionType = "CheReady"
+	CheNotReady    toolchainv1alpha1.ConditionType = "CheNotReady"
+	TektonReady    toolchainv1alpha1.ConditionType = "TektonReady"
+	TektonNotReady toolchainv1alpha1.ConditionType = "TektonNotReady"
+
+	// Status condition reasons
+	FailedToCreateCheSubscriptionReason    = "FailedToCreateCheSubscription"
+	FailedToCreateTektonSubscriptionReason = "FailedToCreateTektonSubscription"
+	CreatedCheSubscriptionReason           = "CreatedCheSubscription"
+	CreatedTektonSubscriptionReason        = "CreatedTektonSubscription"
+)
+
+func SubscriptionCreated(conditionType toolchainv1alpha1.ConditionType, reason, message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    conditionType,
+		Status:  v1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+func SubscriptionFailed(conditionType toolchainv1alpha1.ConditionType, reason, message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    conditionType,
+		Status:  v1.ConditionFalse,
+		Reason:  reason,
+		Message: message,
+	}
+}

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -61,9 +61,9 @@ func NewOperatorGroup(ns string) *olmv1.OperatorGroup {
 }
 
 func SubscriptionFailed(message string) toolchainv1alpha1.Condition {
-	return v1alpha1.SubscriptionFailed(v1alpha1.CheNotReady, v1alpha1.FailedToCreateCheSubscriptionReason, message)
+	return v1alpha1.SubscriptionFailed(v1alpha1.CheReady, v1alpha1.FailedToInstallReason, message)
 }
 
 func SubscriptionCreated(message string) toolchainv1alpha1.Condition {
-	return v1alpha1.SubscriptionCreated(v1alpha1.CheReady, v1alpha1.CreatedCheSubscriptionReason, message)
+	return v1alpha1.SubscriptionCreated(v1alpha1.CheReady, v1alpha1.InstalledReason, message)
 }

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -1,6 +1,8 @@
 package che
 
 import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-operator/pkg/apis/toolchain/v1alpha1"
 	olmv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
@@ -8,11 +10,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	SubscriptionName    = "eclipse-che"
+	SubscriptionSuccess = "che operator subscription created"
+)
+
 //NewSubscription for eclipse Che operator
 func NewSubscription(ns string) *olmv1alpha1.Subscription {
 	return &olmv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "eclipse-che",
+			Name:      SubscriptionName,
 			Namespace: ns,
 			Labels:    Labels(),
 		},
@@ -51,4 +58,12 @@ func NewOperatorGroup(ns string) *olmv1.OperatorGroup {
 			TargetNamespaces: []string{ns},
 		},
 	}
+}
+
+func SubscriptionFailed(message string) toolchainv1alpha1.Condition {
+	return v1alpha1.SubscriptionFailed(v1alpha1.CheNotReady, v1alpha1.FailedToCreateCheSubscriptionReason, message)
+}
+
+func SubscriptionCreated(message string) toolchainv1alpha1.Condition {
+	return v1alpha1.SubscriptionCreated(v1alpha1.CheReady, v1alpha1.CreatedCheSubscriptionReason, message)
 }

--- a/pkg/che/che.go
+++ b/pkg/che/che.go
@@ -3,6 +3,7 @@ package che
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-operator/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-operator/pkg/toolchain"
 	olmv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
@@ -21,7 +22,7 @@ func NewSubscription(ns string) *olmv1alpha1.Subscription {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      SubscriptionName,
 			Namespace: ns,
-			Labels:    Labels(),
+			Labels:    toolchain.Labels(),
 		},
 		Spec: &olmv1alpha1.SubscriptionSpec{
 			Channel:                "stable",
@@ -33,15 +34,11 @@ func NewSubscription(ns string) *olmv1alpha1.Subscription {
 	}
 }
 
-func Labels() map[string]string {
-	return map[string]string{"provider": "toolchain-operator"}
-}
-
 func NewNamespace(name string) *v1.Namespace {
 	return &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
-			Labels: Labels(),
+			Labels: toolchain.Labels(),
 		},
 	}
 }
@@ -51,7 +48,7 @@ func NewOperatorGroup(ns string) *olmv1.OperatorGroup {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    ns,
 			GenerateName: ns,
-			Labels:       Labels(),
+			Labels:       toolchain.Labels(),
 		},
 		Spec: olmv1.OperatorGroupSpec{
 

--- a/pkg/controller/installconfig/installconfig_controller_test.go
+++ b/pkg/controller/installconfig/installconfig_controller_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/codeready-toolchain/toolchain-operator/pkg/test/k8s"
 	. "github.com/codeready-toolchain/toolchain-operator/pkg/test/olm"
 	. "github.com/codeready-toolchain/toolchain-operator/pkg/test/toolchain"
+	"github.com/codeready-toolchain/toolchain-operator/pkg/toolchain"
 	"github.com/go-logr/logr"
 	olmv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -48,7 +49,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.True(t, result.Requeue)
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				DoesNotExist()
@@ -70,7 +71,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.True(t, result.Requeue)
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				Exists().
@@ -94,7 +95,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.True(t, result.Requeue)
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				Exists().
@@ -120,7 +121,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.True(t, result.Requeue)
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				Exists().
@@ -146,7 +147,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.False(t, result.Requeue)
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				Exists().
@@ -273,7 +274,7 @@ func TestInstallConfigController(t *testing.T) {
 
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				DoesNotExist()
@@ -326,7 +327,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.EqualError(t, err, fmt.Sprintf("failed to create che subscription in namespace %s: %s", cheOperatorNs, errMsg))
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				Exists().
@@ -381,7 +382,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.EqualError(t, err, fmt.Sprintf("failed to create tekton subscription in namespace %s: %s", tektonSub.Namespace, errMsg))
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				Exists().
@@ -431,7 +432,7 @@ func TestInstallConfigController(t *testing.T) {
 			assert.EqualError(t, err, fmt.Sprintf("[failed to create che subscription in namespace %s: %s, failed to create tekton subscription in namespace %s: %s]", cheSub.Namespace, errMsg, tektonSub.Namespace, errMsg))
 			AssertThatNamespace(t, cheOperatorNs, cl).
 				Exists().
-				HasLabels(che.Labels())
+				HasLabels(toolchain.Labels())
 
 			AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, cl).
 				Exists().
@@ -689,7 +690,7 @@ func TestCreateNamespaceForChe(t *testing.T) {
 		assert.True(t, nsCreated)
 		AssertThatNamespace(t, cheOperatorNs, cl).
 			Exists().
-			HasLabels(che.Labels())
+			HasLabels(toolchain.Labels())
 	})
 
 	t.Run("should not fail if ns exists", func(t *testing.T) {
@@ -705,7 +706,7 @@ func TestCreateNamespaceForChe(t *testing.T) {
 		assert.True(t, nsCreated)
 		AssertThatNamespace(t, cheOperatorNs, cl).
 			Exists().
-			HasLabels(che.Labels())
+			HasLabels(toolchain.Labels())
 
 		// when
 		nsCreated, err = r.ensureCheNamespace(testLogger(), installConfig)
@@ -716,7 +717,7 @@ func TestCreateNamespaceForChe(t *testing.T) {
 		assert.False(t, nsCreated)
 		AssertThatNamespace(t, cheOperatorNs, cl).
 			Exists().
-			HasLabels(che.Labels())
+			HasLabels(toolchain.Labels())
 	})
 
 	t.Run("should fail to create ns", func(t *testing.T) {

--- a/pkg/tekton/tekton.go
+++ b/pkg/tekton/tekton.go
@@ -1,0 +1,45 @@
+package tekton
+
+import (
+	"github.com/codeready-toolchain/toolchain-operator/pkg/apis/toolchain/v1alpha1"
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	SubscriptionNamespace = "openshift-operators"
+	SubscriptionName      = "openshift-pipelines-operator"
+	SubscriptionSuccess   = "tekton operator subscription created"
+)
+
+//NewSubscription for openshift-pipeline operator
+func NewSubscription(ns string) *olmv1alpha1.Subscription {
+	return &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SubscriptionName,
+			Namespace: ns,
+			Labels:    Labels(),
+		},
+		Spec: &olmv1alpha1.SubscriptionSpec{
+			Channel:                "dev-preview",
+			Package:                "openshift-pipelines-operator",
+			StartingCSV:            "openshift-pipelines-operator.v0.5.2",
+			CatalogSource:          "community-operators",
+			CatalogSourceNamespace: "openshift-marketplace",
+		},
+	}
+}
+
+func Labels() map[string]string {
+	return map[string]string{"provider": "toolchain-operator"}
+}
+
+func SubscriptionFailed(message string) toolchainv1alpha1.Condition {
+	return v1alpha1.SubscriptionFailed(v1alpha1.TektonNotReady, v1alpha1.FailedToCreateTektonSubscriptionReason, message)
+}
+
+func SubscriptionCreated(message string) toolchainv1alpha1.Condition {
+	return v1alpha1.SubscriptionCreated(v1alpha1.TektonReady, v1alpha1.CreatedTektonSubscriptionReason, message)
+}

--- a/pkg/tekton/tekton.go
+++ b/pkg/tekton/tekton.go
@@ -37,9 +37,9 @@ func Labels() map[string]string {
 }
 
 func SubscriptionFailed(message string) toolchainv1alpha1.Condition {
-	return v1alpha1.SubscriptionFailed(v1alpha1.TektonNotReady, v1alpha1.FailedToCreateTektonSubscriptionReason, message)
+	return v1alpha1.SubscriptionFailed(v1alpha1.TektonReady, v1alpha1.FailedToInstallReason, message)
 }
 
 func SubscriptionCreated(message string) toolchainv1alpha1.Condition {
-	return v1alpha1.SubscriptionCreated(v1alpha1.TektonReady, v1alpha1.CreatedTektonSubscriptionReason, message)
+	return v1alpha1.SubscriptionCreated(v1alpha1.TektonReady, v1alpha1.InstalledReason, message)
 }

--- a/pkg/tekton/tekton.go
+++ b/pkg/tekton/tekton.go
@@ -2,6 +2,7 @@ package tekton
 
 import (
 	"github.com/codeready-toolchain/toolchain-operator/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-operator/pkg/toolchain"
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
@@ -20,7 +21,7 @@ func NewSubscription(ns string) *olmv1alpha1.Subscription {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      SubscriptionName,
 			Namespace: ns,
-			Labels:    Labels(),
+			Labels:    toolchain.Labels(),
 		},
 		Spec: &olmv1alpha1.SubscriptionSpec{
 			Channel:                "dev-preview",
@@ -30,10 +31,6 @@ func NewSubscription(ns string) *olmv1alpha1.Subscription {
 			CatalogSourceNamespace: "openshift-marketplace",
 		},
 	}
-}
-
-func Labels() map[string]string {
-	return map[string]string{"provider": "toolchain-operator"}
 }
 
 func SubscriptionFailed(message string) toolchainv1alpha1.Condition {

--- a/pkg/test/olm/operator_group.go
+++ b/pkg/test/olm/operator_group.go
@@ -2,7 +2,7 @@ package olm
 
 import (
 	"context"
-	"github.com/codeready-toolchain/toolchain-operator/pkg/che"
+	"github.com/codeready-toolchain/toolchain-operator/pkg/toolchain"
 	testwait "github.com/codeready-toolchain/toolchain-operator/test/wait"
 	olmv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +24,7 @@ func (a *OperatorGroupAssertion) loadOperatorGroupAssertion() error {
 		return nil
 	}
 	ogList := &olmv1.OperatorGroupList{}
-	err := a.client.List(context.TODO(), ogList, client.InNamespace(a.namespacedName.Namespace), client.MatchingLabels(che.Labels()))
+	err := a.client.List(context.TODO(), ogList, client.InNamespace(a.namespacedName.Namespace), client.MatchingLabels(toolchain.Labels()))
 
 	a.ogList = ogList.Items
 	return err

--- a/pkg/toolchain/toolchain.go
+++ b/pkg/toolchain/toolchain.go
@@ -1,0 +1,5 @@
+package toolchain
+
+func Labels() map[string]string {
+	return map[string]string{"provider": "toolchain-operator"}
+}

--- a/test/e2e/toolchain_test.go
+++ b/test/e2e/toolchain_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/codeready-toolchain/toolchain-operator/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-operator/pkg/test/k8s"
 	. "github.com/codeready-toolchain/toolchain-operator/pkg/test/olm"
-	"github.com/codeready-toolchain/toolchain-operator/pkg/test/toolchain"
 	. "github.com/codeready-toolchain/toolchain-operator/pkg/test/toolchain"
+	"github.com/codeready-toolchain/toolchain-operator/pkg/toolchain"
 	"github.com/codeready-toolchain/toolchain-operator/test/wait"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
@@ -30,7 +30,7 @@ func TestToolchain(t *testing.T) {
 
 	ctx, await := InitOperator(t)
 	defer ctx.Cleanup()
-	cheOperatorNs := toolchain.GenerateName("che-op")
+	cheOperatorNs := GenerateName("che-op")
 	cheOg := che.NewOperatorGroup(cheOperatorNs)
 	cheSub := che.NewSubscription(cheOperatorNs)
 	tektonSub := tekton.NewSubscription(tekton.SubscriptionNamespace)
@@ -53,7 +53,7 @@ func TestToolchain(t *testing.T) {
 
 		AssertThatNamespace(t, cheOperatorNs, f.Client).
 			Exists().
-			HasLabels(che.Labels())
+			HasLabels(toolchain.Labels())
 
 		AssertThatOperatorGroup(t, cheOg.Namespace, cheOg.Name, f.Client).
 			Exists().


### PR DESCRIPTION
*Changes Proposed in this PR*
- This PR creates Tekton subscription  in namespace `openshift-operators` when you create installconfig CRD.
- Update Reconcile logic to not block if creation of any subscription failed above other subscription