### PR TITLE
fix: add missing cluster permissions to CSV

### DIFF
--- a/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/codeready-toolchain-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/codeready-toolchain-operator.v0.0.1.clusterserviceversion.yaml
@@ -65,6 +65,54 @@ spec:
     mediatype: image/png
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          - operatorgroups
+          verbs:
+          - get
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          - clusterserviceversions
+          - installplans
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - toolchain.openshift.dev
+          resources:
+          - cheinstallations/finalizers
+          - tektoninstallations/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - toolchain.openshift.dev
+          resources:
+          - cheinstallations
+          - tektoninstallations
+          - cheinstallations/status
+          - tektoninstallations/status
+          verbs:
+          - '*'
+        serviceAccountName: toolchain-operator
       deployments:
       - name: toolchain-operator
         spec:

--- a/deploy/olm-catalog/csv-config.yaml
+++ b/deploy/olm-catalog/csv-config.yaml
@@ -1,0 +1,6 @@
+operator-path: deploy/operator.yaml
+role-paths:
+- deploy/role.yaml
+- deploy/cluster_role.yaml
+crd-cr-paths:
+- deploy/crds

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -253,6 +253,54 @@ data:
           mediatype: image/png
         install:
           spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - operators.coreos.com
+                resources:
+                - subscriptions
+                - operatorgroups
+                verbs:
+                - get
+                - create
+                - list
+                - watch
+              - apiGroups:
+                - operators.coreos.com
+                resources:
+                - catalogsources
+                - clusterserviceversions
+                - installplans
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+                - create
+                - list
+                - watch
+              - apiGroups:
+                - toolchain.openshift.dev
+                resources:
+                - cheinstallations/finalizers
+                - tektoninstallations/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - toolchain.openshift.dev
+                resources:
+                - cheinstallations
+                - tektoninstallations
+                - cheinstallations/status
+                - tektoninstallations/status
+                verbs:
+                - '*'
+              serviceAccountName: toolchain-operator
             deployments:
             - name: toolchain-operator
               spec:


### PR DESCRIPTION
We were missing `csv-config.json` file that would define the `cluster_role.yaml` file