### PR TITLE
chore: update OSP to 0.8.1

### DIFF
--- a/pkg/controller/cheinstallation/che.go
+++ b/pkg/controller/cheinstallation/che.go
@@ -20,6 +20,8 @@ const (
 	OperatorGroupName = InstallationName
 	// SubscriptionName the name of the OLM subscription for Che
 	SubscriptionName = "eclipse-che"
+	// StartingCSV keeps the CSV version the installation should start with
+	StartingCSV = "eclipse-che.v7.4.0"
 )
 
 // NewInstallation returns a new CheInstallation resource
@@ -47,7 +49,7 @@ func NewSubscription(ns string) *olmv1alpha1.Subscription {
 		Spec: &olmv1alpha1.SubscriptionSpec{
 			Channel:                "stable",
 			Package:                "eclipse-che",
-			StartingCSV:            "eclipse-che.v7.2.0",
+			StartingCSV:            StartingCSV,
 			CatalogSource:          "community-operators",
 			CatalogSourceNamespace: "openshift-marketplace",
 		},

--- a/pkg/controller/tektoninstallation/tekton.go
+++ b/pkg/controller/tektoninstallation/tekton.go
@@ -16,6 +16,8 @@ const (
 	SubscriptionNamespace = "openshift-operators"
 	// SubscriptionName the name for of TekTon Subscription resource
 	SubscriptionName = "openshift-pipelines-operator"
+	// StartingCSV keeps the CSV version the installation should start with
+	StartingCSV = "openshift-pipelines-operator.v0.8.1"
 )
 
 // NewInstallation returns a new TektonInstallation resource
@@ -38,7 +40,7 @@ func NewSubscription(ns string) *olmv1alpha1.Subscription {
 		Spec: &olmv1alpha1.SubscriptionSpec{
 			Channel:                "dev-preview",
 			Package:                "openshift-pipelines-operator",
-			StartingCSV:            "openshift-pipelines-operator.v0.5.2",
+			StartingCSV:            StartingCSV,
 			CatalogSource:          "community-operators",
 			CatalogSourceNamespace: "openshift-marketplace",
 		},


### PR DESCRIPTION
update OSP to 0.8.1 to avoid several updates when the installation is finished and defines the startingCSV as a constant