### PR TITLE
include CheURL in CheInstallation.Status once install of Che is complete

### DIFF
--- a/deploy/crds/toolchain.openshift.dev_cheinstallations.yaml
+++ b/deploy/crds/toolchain.openshift.dev_cheinstallations.yaml
@@ -59,6 +59,10 @@ spec:
         status:
           description: CheInstallationStatus defines the observed state of CheInstallation
           properties:
+            CheServerURL:
+              description: CheServerURL the URL of the Che Server, once the installation
+                completed
+              type: string
             conditions:
               description: 'Conditions is an array of current CheInstallation conditions
                 Supported condition types: CheReady'

--- a/deploy/crds/toolchain.openshift.dev_cheinstallations.yaml
+++ b/deploy/crds/toolchain.openshift.dev_cheinstallations.yaml
@@ -59,7 +59,7 @@ spec:
         status:
           description: CheInstallationStatus defines the observed state of CheInstallation
           properties:
-            CheServerURL:
+            cheServerURL:
               description: CheServerURL the URL of the Che Server, once the installation
                 completed
               type: string

--- a/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/codeready-toolchain-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/codeready-toolchain-operator.v0.0.1.clusterserviceversion.yaml
@@ -6,6 +6,24 @@ metadata:
       [
         {
           "apiVersion": "toolchain.openshift.dev/v1alpha1",
+          "kind": "TektonInstallation",
+          "metadata": {
+            "name": "tekton-installation"
+          },
+          "spec": {},
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2019-12-16T09:20:19Z",
+                "reason": "Installed",
+                "status": "True",
+                "type": "TektonReady"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "toolchain.openshift.dev/v1alpha1",
           "kind": "CheInstallation",
           "metadata": {
             "name": "toolchain-cheinstallation"
@@ -22,24 +40,6 @@ metadata:
                 "reason": "Installed",
                 "status": "True",
                 "type": "CheReady"
-              }
-            ]
-          }
-        },
-        {
-          "apiVersion": "toolchain.openshift.dev/v1alpha1",
-          "kind": "TektonInstallation",
-          "metadata": {
-            "name": "tekton-installation"
-          },
-          "spec": {},
-          "status": {
-            "conditions": [
-              {
-                "lastTransitionTime": "2019-12-16T09:20:19Z",
-                "reason": "Installed",
-                "status": "True",
-                "type": "TektonReady"
               }
             ]
           }
@@ -81,6 +81,11 @@ spec:
         path: conditions
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.conditions
+      - description: Route to access CodeReady Workspaces
+        displayName: CodeReady Workspaces URL
+        path: CheServerURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
       version: v1alpha1
     - description: TektonInstallation defines how OpenShift Pipelines (Tekton) operator
         should be installed

--- a/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/toolchain.openshift.dev_cheinstallations.yaml
+++ b/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/toolchain.openshift.dev_cheinstallations.yaml
@@ -59,6 +59,10 @@ spec:
         status:
           description: CheInstallationStatus defines the observed state of CheInstallation
           properties:
+            CheServerURL:
+              description: CheServerURL the URL of the Che Server, once the installation
+                completed
+              type: string
             conditions:
               description: 'Conditions is an array of current CheInstallation conditions
                 Supported condition types: CheReady'

--- a/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/toolchain.openshift.dev_cheinstallations.yaml
+++ b/deploy/olm-catalog/codeready-toolchain-operator/0.0.1/toolchain.openshift.dev_cheinstallations.yaml
@@ -59,7 +59,7 @@ spec:
         status:
           description: CheInstallationStatus defines the observed state of CheInstallation
           properties:
-            CheServerURL:
+            cheServerURL:
               description: CheServerURL the URL of the Che Server, once the installation
                 completed
               type: string

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -68,7 +68,7 @@ data:
               status:
                 description: CheInstallationStatus defines the observed state of CheInstallation
                 properties:
-                  CheServerURL:
+                  cheServerURL:
                     description: CheServerURL the URL of the Che Server, once the installation
                       completed
                     type: string
@@ -282,8 +282,8 @@ data:
               path: conditions
               x-descriptors:
               - urn:alm:descriptor:io.kubernetes.conditions
-            - description: The URL to Che
-              displayName: Che URL
+            - description: Route to access CodeReady Workspaces
+              displayName: CodeReady Workspaces URL
               path: CheServerURL
               x-descriptors:
               - urn:alm:descriptor:org.w3:link

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -68,6 +68,10 @@ data:
               status:
                 description: CheInstallationStatus defines the observed state of CheInstallation
                 properties:
+                  CheServerURL:
+                    description: CheServerURL the URL of the Che Server, once the installation
+                      completed
+                    type: string
                   conditions:
                     description: 'Conditions is an array of current CheInstallation conditions
                       Supported condition types: CheReady'
@@ -203,6 +207,24 @@ data:
             [
               {
                 "apiVersion": "toolchain.openshift.dev/v1alpha1",
+                "kind": "TektonInstallation",
+                "metadata": {
+                  "name": "tekton-installation"
+                },
+                "spec": {},
+                "status": {
+                  "conditions": [
+                    {
+                      "lastTransitionTime": "2019-12-16T09:20:19Z",
+                      "reason": "Installed",
+                      "status": "True",
+                      "type": "TektonReady"
+                    }
+                  ]
+                }
+              },
+              {
+                "apiVersion": "toolchain.openshift.dev/v1alpha1",
                 "kind": "CheInstallation",
                 "metadata": {
                   "name": "toolchain-cheinstallation"
@@ -219,24 +241,6 @@ data:
                       "reason": "Installed",
                       "status": "True",
                       "type": "CheReady"
-                    }
-                  ]
-                }
-              },
-              {
-                "apiVersion": "toolchain.openshift.dev/v1alpha1",
-                "kind": "TektonInstallation",
-                "metadata": {
-                  "name": "tekton-installation"
-                },
-                "spec": {},
-                "status": {
-                  "conditions": [
-                    {
-                      "lastTransitionTime": "2019-12-16T09:20:19Z",
-                      "reason": "Installed",
-                      "status": "True",
-                      "type": "TektonReady"
                     }
                   ]
                 }
@@ -278,6 +282,11 @@ data:
               path: conditions
               x-descriptors:
               - urn:alm:descriptor:io.kubernetes.conditions
+            - description: The URL to Che
+              displayName: Che URL
+              path: CheServerURL
+              x-descriptors:
+              - urn:alm:descriptor:org.w3:link
             version: v1alpha1
           - description: TektonInstallation defines how OpenShift Pipelines (Tekton) operator
               should be installed

--- a/pkg/apis/toolchain/v1alpha1/cheinstallation_types.go
+++ b/pkg/apis/toolchain/v1alpha1/cheinstallation_types.go
@@ -23,6 +23,11 @@ type CheInstallationStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+	// +optional
+
+	// CheServerURL the URL of the Che Server, once the installation completed
+	// +optional
+	CheServerURL string `json:"CheServerURL,omitempty"`
 
 	// Conditions is an array of current CheInstallation conditions
 	// Supported condition types:

--- a/pkg/apis/toolchain/v1alpha1/cheinstallation_types.go
+++ b/pkg/apis/toolchain/v1alpha1/cheinstallation_types.go
@@ -27,7 +27,7 @@ type CheInstallationStatus struct {
 
 	// CheServerURL the URL of the Che Server, once the installation completed
 	// +optional
-	CheServerURL string `json:"CheServerURL,omitempty"`
+	CheServerURL string `json:"cheServerURL,omitempty"`
 
 	// Conditions is an array of current CheInstallation conditions
 	// Supported condition types:

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -109,6 +109,13 @@ func schema_pkg_apis_toolchain_v1alpha1_CheInstallationStatus(ref common.Referen
 				Description: "CheInstallationStatus defines the observed state of CheInstallation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"CheServerURL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CheServerURL the URL of the Che Server, once the installation completed",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/toolchain/v1alpha1/zz_generated.openapi.go
@@ -109,7 +109,7 @@ func schema_pkg_apis_toolchain_v1alpha1_CheInstallationStatus(ref common.Referen
 				Description: "CheInstallationStatus defines the observed state of CheInstallation",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"CheServerURL": {
+					"cheServerURL": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CheServerURL the URL of the Che Server, once the installation completed",
 							Type:        []string{"string"},

--- a/test/assert/che_cluster.go
+++ b/test/assert/che_cluster.go
@@ -28,6 +28,12 @@ func AssertThatCheCluster(t *testing.T, ns, name string, client client.Reader) *
 	}
 }
 
+func (a *CheClusterAssertion) Get() *orgv1.CheCluster {
+	err := a.loadCheClusterAssertion()
+	require.NoError(a.t, err)
+	return a.cheCluster
+}
+
 func (a *CheClusterAssertion) Exists() *CheClusterAssertion {
 	err := a.loadCheClusterAssertion()
 	require.NoError(a.t, err)
@@ -44,6 +50,12 @@ func (a *CheClusterAssertion) HasNoOwnerRef() *CheClusterAssertion {
 func (a *CheClusterAssertion) HasRunningStatus(want string) *CheClusterAssertion {
 	a.Exists()
 	assert.Equal(a.t, want, a.cheCluster.Status.CheClusterRunning)
+	return a
+}
+
+func (a *CheClusterAssertion) HasServerURL(want string) *CheClusterAssertion {
+	a.Exists()
+	assert.Equal(a.t, want, a.cheCluster.Status.CheURL)
 	return a
 }
 

--- a/test/assert/che_installation.go
+++ b/test/assert/che_installation.go
@@ -82,6 +82,13 @@ func (a *CheInstallationAssertion) HasConditions(expected ...toolchainv1alpha1.C
 func (a *CheInstallationAssertion) HasNoCondition() *CheInstallationAssertion {
 	err := a.loadCheInstallationAssertion()
 	require.NoError(a.t, err)
-	AssertConditionsMatch(a.t, a.cheInstallation.Status.Conditions)
+	AssertConditionsEmpty(a.t, a.cheInstallation.Status.Conditions)
+	return a
+}
+
+func (a *CheInstallationAssertion) HasServerURL(want string) *CheInstallationAssertion {
+	err := a.loadCheInstallationAssertion()
+	require.NoError(a.t, err)
+	assert.Equal(a.t, want, a.cheInstallation.Status.CheServerURL)
 	return a
 }

--- a/test/assert/conditions.go
+++ b/test/assert/conditions.go
@@ -24,6 +24,11 @@ func AssertConditionsMatch(t *testing.T, actual []toolchainv1alpha1.Condition, e
 	}
 }
 
+// AssertConditionsEmpty verifies that the actual conditions are empty
+func AssertConditionsEmpty(t *testing.T, actual []toolchainv1alpha1.Condition) {
+	require.Empty(t, actual)
+}
+
 // AssertContainsCondition asserts that the specified list of conditions contains the specified condition.
 // LastTransitionTime is ignored.
 func AssertContainsCondition(t *testing.T, conditions []toolchainv1alpha1.Condition, contains toolchainv1alpha1.Condition) {

--- a/test/e2e/toolchain_test.go
+++ b/test/e2e/toolchain_test.go
@@ -79,7 +79,7 @@ func TestToolchain(t *testing.T) {
 	// 	checkCheResources(t, f.Client.Client, cheOperatorNS, cheOg, cheSub, cheCluster)
 	// })
 
-	t.Run("should recreate deleted operatorgroup for Che", func(t *testing.T) {
+	t.Run("should recreate deleted operator group for che", func(t *testing.T) {
 		// given
 		ogList := &olmv1.OperatorGroupList{}
 		err := await.Client.List(context.TODO(), ogList, client.InNamespace(cheOperatorNS), client.MatchingLabels(toolchain.Labels()))
@@ -208,9 +208,12 @@ func checkCheResources(t *testing.T, client client.Client, cheOperatorNs string,
 			HasSpec(cheSub.Spec)
 	}
 	if cheCluster != nil {
-		AssertThatCheCluster(t, cheCluster.Namespace, cheCluster.Name, client).
+		cheCluster := AssertThatCheCluster(t, cheCluster.Namespace, cheCluster.Name, client).
 			Exists().
-			HasRunningStatus(cheinstallation.AvailableStatus)
+			HasRunningStatus(cheinstallation.AvailableStatus).
+			Get()
+		AssertThatCheInstallation(t, "", cheinstallation.InstallationName, client).
+			HasServerURL(cheCluster.Status.CheURL)
 	}
 }
 


### PR DESCRIPTION
When the CheCluster is in `ready/Available` state, copy its
`status.CheURL` into the `CheInstallation.Status.CheServerURL` field

Fixes https://issues.redhat.com/browse/CRT-406

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>