### PR TITLE
chore: fix the manifests targets and also their description

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,6 +115,6 @@ Increment the `CSV_VERSION_TO_GENERATE` variable in the link:./make/manifests.mk
 ===== 5. Open PR in toolchain-operator
 Open also a PR with the manifests (and all other changes) inside of the toolchain-operator repository.
 
-===== 6. Wait for community-operators PR being merged
+===== 6. Wait for community-operators PR to be merged
 Once the PR in community-operators repo is merged, then the release will be available in Operator Hub.
 So, merge the PR in toolchain-operator repo and verify the new release in your dev cluster.

--- a/README.adoc
+++ b/README.adoc
@@ -108,8 +108,13 @@ If you want to also try to install it from the quay.io using the `OperatorSource
 ===== 3. Create PR in community-operators
 As soon as you verify that the release is working correctly, you can create a PR with a new release in https://github.com/operator-framework/community-operators[community-operators] repo.
 To copy the manifests to the repo use `make copy-manifests-to-community-operators` and then create a PR there. Please follow the instructions that are written in the template of the PR description.
-Open also a PR with the manifests inside of the toolchain-operator repository.
 
-===== 4. Merge PR in toolchain-operator and verify
+===== 4. Prepare for the next release
+Increment the `CSV_VERSION_TO_GENERATE` variable in the link:./make/manifests.mk[manifests.mk] file to the next expected version.
+
+===== 5. Open PR in toolchain-operator
+Open also a PR with the manifests (and all other changes) inside of the toolchain-operator repository.
+
+===== 6. Wait for community-operators PR being merged
 Once the PR in community-operators repo is merged, then the release will be available in Operator Hub.
 So, merge the PR in toolchain-operator repo and verify the new release in your dev cluster.

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,14 +1,15 @@
-CSV_VERSION_TO_GENERATE := 0.1.2
+CSV_VERSION_TO_GENERATE := 0.1.3
 DATE_SUFFIX := $(shell date +'%d%H%M%S')
 COMMUNITY_OPERATORS_DIR=../../operator-framework/community-operators/community-operators/codeready-toolchain-operator
 
 PATH_TO_CREATE_RELEASE_FILE= scripts/create-release-bundle.sh
-PATH_TO_PUSH_MANIFESTS_FILE= scripts/push-to-quay-manifests.sh
+PATH_TO_PUSH_MANIFEST_FILE= scripts/push-to-quay-manifest.sh
 PATH_TO_CREATE_HACK_FILE= scripts/generate-deploy-hack.sh
 
 PHONY: create-release-manifest
+## Creates release manifest in ./manifest/ directory
 create-release-manifest:
-	$(eval CREATE_PARAMS = -pr ../toolchain-operator -on codeready-toolchain-operator  --next-version ${CSV_VERSION_TO_GENERATE})
+	$(eval CREATE_PARAMS = -pr ../toolchain-operator -on codeready-toolchain-operator  --next-version ${CSV_VERSION_TO_GENERATE} --quay-namespace codeready-toolchain)
 ifneq ("$(wildcard ../api/$(PATH_TO_CREATE_RELEASE_FILE))","")
 	@echo "creating release manifest in ./manifest/ directory using script from local api repo..."
 	../api/${PATH_TO_CREATE_RELEASE_FILE} ${CREATE_PARAMS}
@@ -18,17 +19,19 @@ else
 endif
 
 PHONY: push-latest-release-manifest
+## Pushes the latest release manifest from ./manifest/ directory into quay namespace
 push-latest-release-manifest:
 	$(eval PUSH_PARAMS = -pr ../toolchain-operator -on codeready-toolchain-operator)
-ifneq ("$(wildcard ../api/$(PATH_TO_PUSH_MANIFESTS_FILE))","")
+ifneq ("$(wildcard ../api/$(PATH_TO_PUSH_MANIFEST_FILE))","")
 	@echo "pushing the latest release manifest from ./manifest/ directory using script from local api repo..."
-	../api/${PATH_TO_PUSH_MANIFESTS_FILE} ${PUSH_PARAMS}
+	../api/${PATH_TO_PUSH_MANIFEST_FILE} ${PUSH_PARAMS}
 else
 	@echo "ushing the latest release manifest from ./manifest/ directory using script from GH api repo (using latest version in master)..."
-	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_PUSH_MANIFESTS_FILE} | bash -s -- ${PUSH_PARAMS}
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_PUSH_MANIFEST_FILE} | bash -s -- ${PUSH_PARAMS}
 endif
 
 PHONY: copy-manifests-to-community-operators
+## Copies the ./manifest/ directory into community-operators/codeready-toolchain-operator/ directory
 copy-manifests-to-community-operators:
 ifeq ("$(wildcard $(COMMUNITY_OPERATORS_DIR))","")
 	$(error The directory ${COMMUNITY_OPERATORS_DIR} is not available. Clone the repository and pull the latest changes, then run the target again.)
@@ -37,6 +40,7 @@ endif
 	cp -r manifests/* ${COMMUNITY_OPERATORS_DIR}/
 
 PHONY: delete-release-manifest-from-os
+## Deletes CatalogSource 'source-codeready-toolchain-operator' and ConfigMap 'cm-codeready-toolchain-operator' from OpenShift
 delete-release-manifest-from-os:
 	oc delete catalogsource source-codeready-toolchain-operator -n openshift-marketplace 2>/dev/null || true
 	oc delete configmap cm-codeready-toolchain-operator -n openshift-marketplace 2>/dev/null || true
@@ -46,10 +50,10 @@ delete-release-manifest-from-os:
 add-release-manifests-to-os:
 	$(eval CREATE_PARAMS = -crds ./deploy/crds -csvs ./manifests/ -pf ./manifests/codeready-toolchain-operator.package.yaml -hd /tmp/hack_deploy_crt-operator_${DATE_SUFFIX} -on codeready-toolchain-operator)
 ifneq ("$(wildcard ../api/$(PATH_TO_CREATE_HACK_FILE))","")
-	@echo "creating release manifest in ./manifest/ directory using script from local api repo..."
+	@echo "adding release manifests from ./manifest/ directory to OpenShift using script from local api repo..."
 	../api/${PATH_TO_CREATE_HACK_FILE} ${CREATE_PARAMS}
 else
-	@echo "creating release manifest in ./manifest/ directory using script from GH api repo (using latest version in master)..."
+	@echo "adding release manifests from ./manifest/ directory to OpenShift using script from GH api repo (using latest version in master)..."
 	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_CREATE_HACK_FILE} | bash -s -- ${CREATE_PARAMS}
 endif
 	cat /tmp/hack_deploy_crt-operator_${DATE_SUFFIX}/deploy_csv.yaml | oc apply -f -


### PR DESCRIPTION
This PR:
* fixes description of the makefile targets
* increments `CSV_VERSION_TO_GENERATE` var to prepare for the next version
* renames the expected name of `scripts/push-to-quay-manifests.sh` script to `scripts/push-to-quay-manifest.sh` as is proposed here: https://github.com/codeready-toolchain/api/pull/103