### PR TITLE
chore: add bundle metadata and Dockerfile

### DIFF
--- a/deploy/olm-catalog/codeready-toolchain-operator/bundle.Dockerfile
+++ b/deploy/olm-catalog/codeready-toolchain-operator/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=codeready-toolchain-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/deploy/olm-catalog/codeready-toolchain-operator/metadata/annotations.yaml
+++ b/deploy/olm-catalog/codeready-toolchain-operator/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+  operators.operatorframework.io.bundle.package.v1: "codeready-toolchain-operator"
+  operators.operatorframework.io.bundle.channels.v1: "alpha"
+  operators.operatorframework.io.bundle.channel.default.v1: "alpha"


### PR DESCRIPTION
Adds two files needed by opm and by operator registry.
* `bundle.Dockerfile` used for the operator bundle image
* `metadata/annotations.yaml` containing metadata info about the operator bundle
