### PR TITLE
Toolchain operator v0.1.3

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,6 +113,7 @@ EOF
 To delete the CSVs from the cluster, you can run `make delete-release-manifest-from-os`.
 
 If you want to also try to install it from the quay.io using the `OperatorSource` you can push the bundle into your quay namespace using `make push-latest-release-manifest`
+Note: You must `export QUAY_NAMESPACE=<your quay namespace>` before running the script. If you get authorization errors when trying to push the release to quay, you may need to https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md#quay-login[retrieve and set the quay token manually] and make the repository public.
 
 ===== 3. Create PR in community-operators
 As soon as you verify that the release is working correctly, you can create a PR with a new release in https://github.com/operator-framework/community-operators[community-operators] repo.

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,4 +1,4 @@
-CSV_VERSION_TO_GENERATE := 0.1.3
+CSV_VERSION_TO_GENERATE := 0.1.4
 DATE_SUFFIX := $(shell date +'%d%H%M%S')
 COMMUNITY_OPERATORS_DIR=../../operator-framework/community-operators/community-operators/codeready-toolchain-operator
 

--- a/manifests/0.1.3/codeready-toolchain-operator.clusterserviceversion.yaml
+++ b/manifests/0.1.3/codeready-toolchain-operator.clusterserviceversion.yaml
@@ -1,0 +1,316 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "toolchain.openshift.dev/v1alpha1",
+          "kind": "CheInstallation",
+          "metadata": {
+            "name": "toolchain-cheinstallation"
+          },
+          "spec": {
+            "cheOperatorSpec": {
+              "namespace": "toolchain-workspaces"
+            }
+          },
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2019-12-16T09:37:11Z",
+                "reason": "Installed",
+                "status": "True",
+                "type": "CheReady"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "toolchain.openshift.dev/v1alpha1",
+          "kind": "TektonInstallation",
+          "metadata": {
+            "name": "tekton-installation"
+          },
+          "spec": {},
+          "status": {
+            "conditions": [
+              {
+                "lastTransitionTime": "2019-12-16T09:20:19Z",
+                "reason": "Installed",
+                "status": "True",
+                "type": "TektonReady"
+              }
+            ]
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Developer Tools, Integration & Delivery, OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/codeready-toolchain/toolchain-operator@sha256:3106578a6437854cb1bd59ae212e1e2a58ffd9b70cad2fe2f91efd79d3b6fa17
+    createdAt: 2020-06-18T13:29:55Z
+    description: CodeReady Toolchain is a suite of dev tools and runtimes for development
+      and deployment of cloud-native applications on OpenShift. CodeReady Toolchain
+      provides an easy way to deploy and configure the set of Red Hat curated developer
+      tools and runtimes to the OpenShift cluster. The developer tools can be accessed
+      from the Dev Perspective of the OpenShift console.
+    repository: https://github.com/codeready-toolchain/toolchain-operator
+    support: Red Hat, Inc.
+  name: codeready-toolchain-operator.v0.1.3
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: CheInstallation defines how CodeReady Workspaces (Che) operator
+        should be installed
+      displayName: CodeReady Workspaces Installation
+      kind: CheInstallation
+      name: cheinstallations.toolchain.openshift.dev
+      specDescriptors:
+      - description: The namespace where the CodeReady Workspaces operator will be
+          installed
+        displayName: Namespace
+        path: cheOperatorSpec.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      statusDescriptors:
+      - description: Route to access CodeReady Workspaces
+        displayName: CodeReady Workspaces URL
+        path: cheServerURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: 'Last known condition of the CodeReady Workspaces  operator installation.
+          Supported condition types: CheReady'
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+    - description: TektonInstallation defines how OpenShift Pipelines (Tekton) operator
+        should be installed
+      displayName: OpenShift Pipelines Installation
+      kind: TektonInstallation
+      name: tektoninstallations.toolchain.openshift.dev
+      statusDescriptors:
+      - description: 'Last known condition of the OpenShift Pipelines operator installation.
+          Supported condition types: TektonReady'
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+  description: |
+    # CodeReady Toolchain
+    CodeReady Toolchain is a suite of dev tools and runtimes for development and deployment of cloud-native applications on OpenShift. CodeReady Toolchain provides an easy way to deploy and configure the set of Red Hat curated developer tools and runtimes to the OpenShift cluster. The developer tools can be accessed from the Dev Perspective of the OpenShift console.
+
+
+    ## Bundled Developer Tools
+    CodeReady Toolchain automatically installs and configures the following developer tool operators:
+    * Red Hat CodeReady Workspaces
+    * OpenShift Pipelines
+
+
+    ## Installation
+    CodeReady Toolchain Operator is a cluster-wide operator. It installs and configures the operators for the bundled developer tools to be available across all namespaces in the cluster. CodeReady Toolchain Operator and OpenShift Pipelines get installed in default `openshift-operators` namespace and Red Hat CodeReady Workspaces in single `toolchain-workspaces` namespace.
+
+
+    ### Installation Pre-requisites
+    * OAuth-based authentication has been enabled and configured for the OpenShift cluster.
+    * One regular user (not the default kubeadmin) exists in the OpenShift cluster.
+
+    You can find information about configuring the cluster OAuth in [OpenShift Container Platform documentation](https://docs.openshift.com/container-platform/4.2/authentication/understanding-identity-provider.html).
+
+
+    ##### _**Warning**: This operator should be installed in OpenShift Container Platform clusters only. Installing on OKD or other platforms will result in errors._
+  displayName: Red Hat CodeReady Toolchain
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAZMAAAGPCAYAAACZCD2BAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAABJ2UlEQVR42u3deXxcZ3k2/ut+zsxodbxblixLI1mW7CheEsuO7awOhgCBUgKkQAst/FoobymUJfECLaKBxJCwlPKmbC8tJYUStrCWQhJnt63FdmzLiyRbsi2NFu/WMjNnee7fH7aDCVpG0sw8s9zfT6FodObMdY5tXXrO8hxACCGEEEIIIYQQQgghhBBCCCGEEFNGpgMIkQgttbWFw8PuAgWepxkLCDwDoBkMzABoBsDTcel/Twd4BoCcK+9loJAA/yirHgTgXP7fYRAil98UZcZZIpwFcIaIz2pNl74mPkOazzjkOzvH5/Ysbm+Pmt4/QsSblIlIOy21tYGBsC73a65kcCUYlSAuY0YJERcxqARAgemcY+gFcBLASQKfZKhOsD4JRSdJWyfrjh/qMR1QiImSMhEpa08wOMMh/3LStAyE5QAWA6gEUArAMp0vgQYAHGTGfiIcBPEBy1UtN5w8EjIdTIjRSJmIlNBYVl3JCqsVsEIzlhHRcoDLTOdKMecYOECgg4Deo4l2Hu9oPXAP4JkOJoSUiUi63VVVc7Vn3a4ZNxPxKjCWA5hmOldaYrhEaGXgeRBeYE83rz7RfpAANh1NZBcpE5FwuxYsma183u1QtAGMWwFci8w+TGXacQA7mfGsIjxV19l62HQgkfmkTETc7VqwZLYV4DuYeSOAjbh0nkOYMwDGLiJ6gjQ9ccOJw7tl5CLiTcpExEVzRc1yZn49A68DsA6jX1orTGO0g/AUEz2pLe83a9vbL5qOJNKflImYlH1ly2ZGregbwXgDGBtAmGM6k5gUD4SdzPRD7fN+vLa9vct0IJGepExEzHZWVV1jeepNYLwdwB0Ack1nEnHlAfQ8Qf8Eynu87tixE6YDifQhZSLG9GJpaZ7fyns9lHoHmO+CFEi2YDCaofgxx6Hvre9q7TYdSKQ2KRPxRx4DrIry6jsBvB2EP4VctpvtNIAnQfhufr7/p7UtLYOmA4nUI2UiXtZcUbNcM/8dgLcBmGk6j0hJUWb8Tin6z7x8389qW1ps04FEapAyyXLbg8HcQvjfDKL/D4wNAJTpTCI9ENDNwKPk6W/WnWw/ajqPMEvKJEs1BauXaNAHCPwXAGaZziPSmgbwv1rxI2uOtf2aLn0tsoyUSRZpWrXKz2cH3gHgQ2CsMp1HZKReAN8h5T4iV4NlFymTLLCvbNlMm6LvZcL/gdyNLpIjCsYPNfQjNx5v32E6jEg8KZMMtqtySbXS+mMA/hyp/XwPkckIL5DmB1cdb/u1TOOSuaRMMlBTcPGNmumTRLgL8mcsUsdRBv3rTJ/3NXnaZOaRHzQZpKGs+lVk4dNg3GQ6ixCjoxMMfFHZA9+sC4WGTacR8SFlkgGaKqtvZo1PAHit6SxCxOrypcVfcNzhr63v6gqbziOmRsokjTVULL6VmB4EsN50FiEmjXGaiB6e7vO+LIe/0peUSRpqrqhZrjV/AYSNprMIEUfHQXigrqP1W3KvSvqRMkkju8prKhTx5wC8BXKnushUzAe0hS03Hmv7pekoInZSJmngpaLlBdHc8CYi+ijkEl+RNegXrL0ta060t5hOIsYnZZLCHgOsYLDmgwT+RwCzTecRwgAG41FPOfeu7ejoMx1GjE7KJEVdPrn+ZQDXm84iRAo4T6BteQW+L8lMxalJyiTF7CqvqSDwV4jwBtNZhEhBRxTUh1d1Hv5f00HEH5IySRHbcbtvWnnowwzUg1BoOo8QKYzBeJRgbao7fqjHdBhxiZRJCmguW7JKK/1NyCEtISZigEH/uLrzyL/KpcTmSZkY9GJp7Sy/5XwZhL+A/FkIMVn7lFbvXXXicLPpINlMfoAZ0lhR/W4wPgdgvuksQqQ9hgvCF2b49KfkLnozpEySbF/ZspkRZX+VwO80nUWIDLQXrN+7+nj7HtNBso2USRI1BmvexOBvEDDPdBYhMpgG8K38Av/HaltaBk2HyRZSJknwYmlpnt/K/xwIH4TscyGSgoCDHuGdN3a0vmQ6SzaQH2wJ1lCx+FbF9B0GgqazCJF1Lp1L+WxHZ+v99wCe6TiZTMokQR4DrMqKmq3M/I8A/KbzCJHlfh2wvPesOHq033SQTCVlkgCXZ/f9AYDVprMIIV52noG/XdPZ+gPTQTKRlEmcNVbUvBXM3wIw3XQWIcQIGN8NRHI/sKJv35DpKJlEyiROtuN2X2FFTz2Yt0CeNSJEqtsDjbeuPtF6zHSQTCFlEgeNZdWVIPwAhDrTWYQQMRsA0XtXdxz5kekgmUB+g56ipvKaDVDYKUUiRNqZBuYfNASr/4nlZ+GUychkkhigpmD1pwD8E2Q/CpHm6BmP7D+TB3BNnvwQnISXipYXOHmRbzNwj+ksQog4YXQR8VvrOtt2mY6SjqRMJmhnVVWp5aifymEtITIRDRPrv6k73vY900nSjRwnnIDmiupbLFc1SZEIkak4n4kebQxWf4rll+0JkZ0Vo6bg4r9l0FcBWKazCCGSgOjHjjP0rvVdXWHTUdKBlMk4GKDGYM2XCfwh01mEEMnFwM4cy3uTTMMyPimTMbTU1gaGh5xvAni36SxCCGOOEXBXXWfrYdNBUpmUySiaKiuna+37CQF3mM4ihDDuLEPfvaaz/RnTQVKVnIAfwc6KiiL2fE9IkQghLptFsH7dUFH1RtNBUpWMTF5hZ+XSxZbWTwBcZjqLECLleGB63+rjR75tOkiqkZHJVZorapZb2ntOikQIMQoLxN9qCNZ82HSQVCNlcllzsGqtZn4aQJHpLEKIlEYE/lJjxeJ7TQdJJVImAJrLa+7QrH4HYKbpLEKItEBg+nxjsHqb6SCpIuvPmTQEa15LwI8BzjedRQiRhgj/t66j9e8JYNNRTMrqu7kbK6s3EuNxAFIkQojJWhOaOXvaN8+f+a3pICZl7cikqXzxXUz0EwAB01mEEBmA8a+rj7dm7UwZWVkmDWXVryKFXwDIM51FCJFJ+MurO9s+YjqFCVl3Ar6pvGYDKfo5pEiEEHFH/9BQXnO/6RQmZFWZNASrbmPCL+VkuxAiUYj4k00Viz9pOkfSt9t0gGRpCC5eSaCnIJf/CiESj0H40OqO1q+aDpIsWVEmu8prKhTxCwCKTWcRQmQNZsL713S0ftN0kGTI+DJpCNbOJzgvAqgwnUUIkXWYid69puPIo6aDJFpGl0lTZeV01r7nACwznUUIkbVsxfS6VcePPGU6SCJl7An4tqqqHNa+n0KKRAhhVkAT/7ApWL3EdJBEysgyYUCdd9W/A9hgOosQQgCYBeB/GoK1800HSZSMLJPGYPUnAbzDdA4hhLiCgSDg/PTF0tKMvMct486ZNFTU3EPM/52J2xZHHsADAKCBgUsv0bAG698vQqTABQBAID8B0wAUmA4uRAZ4vKOz9a33AJ7pIPGUUT9wGyqrV5PGM8jeu9vPaubeCPOFKHN0kLWKsvZFGYEo67wI62kOeIbLuGYyK1eA4yO6ECA16AeGchQNF0C5eUp5eUr5A6AcP9FM69Il2DLnmRCjyrxpVzKmTHZWVZVartoFoMR0lkTTzN02o3uA9fA57eZcYG/OkOZij7nQdLYr8kmdKlQUmk6+gemW4nxSMwOgIBNSJqMQJjH4PWs62/7DdI54yYgyealoeYGdF30W4BtMZ4k3De6LaD52Vnv2ae1Nv+i5QQeYYTrXZOWTOj1DqZ7Zlm94hrIK/USLCMg1nUsIAyIEvr2us22X6SDxkPZlwoBqClb/EMDdprPEgwa3DWjuOeV5Vr/nLAyzzujn0RMB05U6OVf5e+dYlpVHtIhA003nEiJJQsRWXd3xQz2mg0xV2pdJU0XNPzLzP5vOMQVnw6wP93qu1+O6i8OsM/bSwVjNUL6OYp+ve46y8gNE10JGLiKDMbBzpk/fvri9PWo6y1SkdZk0Vix+NZh+gzS7xFkzjp313OMnPGfeee0t4Sx/4uVYLKLhYsu3b6HPz/lQyyDnXERGon9f3XnkvaZTTGkLTAeYrIZFixaSZzUDmGs6Syw0+MQ5rY8ec6IlF7WuMZ0nHSkgWqR8+8v9fjufrBVEcqmyyBwE/nBdZ9tXTOeYfP401FJbGxgacp4hYK3pLGMh4Nw5z9t31LXnnNderek8mcQCwqU+/96FVsCXo2glAL/pTEJMCcMF0+2rTxx5wXSUyUjLMmksr/5XED5oOsco2Aa/dMKxB0+6Tp2W4/0JFyA6u9gfaClS/kVEmX9puMhkdMJxfdev72o5azrJhJObDjBRjcHF7wDoe6ZzjODsGc/b1+rY5cPsyXT3ZnCJz7+/whdALtEypOHfbyEAPF7X2Xo3AWw6yESk1T+2nZVLF1uetzuVTsJq0Injrt173Imu9OSu75RRqNTZan9Oxwxl1cp9LCLtEP4+3Z7SmDZl0rRqlZ/PDLwAYLXpLADgQu8/ajuD3Z6zRq7GSl0BooHFvsDeeT5fjQLNM51HiBhFGLxuTWfbXtNBYpU2ZdIYrN4GYJPpHA54d0s0qs5od6XpLCJ2CrAXBXIaF1q+xSSlItLDkfwCf11tS8ug6SCxSIsyaSpffBcT/cJk3rDmxkNOJO+c9q4zvT/E5BFBV/j8e4K+QCmBikznEWIcP1zd2XqP6RCxSPky2bVgyWzLr19iYIGJz/eYWw670eFe102Jw2siPiyQU+MP7Cn2+Zfi0vT6QqSqd6zubP1v0yHGk/Jl0his/imAP0325zIj1O5GO0+4zjqkwX4SkxMgGqwN5O6bpaxVAHJM5xFiBGc8cmrXdnT0mQ4ylpT+IdkQXPweAn07mZ/JQLjfc5sO2pHVco9I9siD6l2Rm9tRQGqd6SxCvBIBP63rbE3pyWxTtkwuT5dyAJjcg5wmwTurvZ0H7Mi1DvNM09svzJhtWa3X+XMtH9Ei01mEuBoBf1XX2fod0znGyJeaknl4S4NPHIjaw6e0s8T0dgvzFOAtDeQ1FlnWSrlHRaSQlD7clZKz7TZU1NyD5BSJc1q7zz0THpovRSKu0IDVYofX7owMD0ZZHzCdR4jLZvvY/2+mQ4wm5UYmOysqiiz2twCYncjPccC7myPhuUOsF5reZpHaFvr8exb7csqIEvt3UohYpOrhrpQbmVja/zASWyTRkOtufzY8tEKKRMTipOtc/0J0mMOaG01nEYKBL7y0aFHK3XibUiOTxvLq14Hw60StXwNHm6Nhuqi9StPbKtJThT+nucLyL5FnqQjD/nN1Z+tfmg5xtZQpk5ba2sLhIecggESMFnS/5z51wI7ewmC5l0BMST5RaHVO/ikf0QrTWUQWU3j16mOtT5iO8fs4KWJo0L4PCSgSZpw+aEcb99uRjVIkIh6GmUuejQ7VnvHcZ5Fm04SLzEEa/9K0alXKPBQuJWa7bS5fvBREj8Y7j8NofjE6NPOC9hab3kaRcVSv55YPad0yz2flEEguIRbJNpciUfsb588+azoIkAIjEwZIE30N8X0WCPd77hPPRgZX2MxyBY5ImH7tXrczGvZc5k7TWUT2YaatjWXVKXEO2HiZNJcvfgeAW+O1PgYuHHai2/fbkY0AfKa3T2S+Ya1nvRAdXjDEvNd0FpF18ljxI6ZDAIZPwLfU1hYODzqHQCiNx/oYfKLZDg9f8LTcgCiSjgDUBnKbiyzfDUihi1tE5mPSf7Kmo/0XJjMYHZkMD7ub41UkLvPB58PD10iRCFMYwAE7suqQEz0CxpDpPCJ7kFZfNH0y3liZ7F5YUwLGR+KxrgjzzucjQ+U2eIap7RHiipDrLGmww+c1oct0FpElCFV8duD9JiMYKxNt8WcBzp/qevo955kXIkM3epCbyETqGNDegmfDQ3PCWu82nUVkCcY/7ytbZmzGcyNlsrOs6loG3jXF1XCX6z61347eBjk+LVKQx5y7IxpeeY7dXaaziKwwM0KRuBztmQwjZWIp9TCmdk+J0+ZEdxxxIneYyC9ErBisdkciN7ba0b0AwqbziMxGRB9vWLTIyJyDSS+TxsrqjQBeN4VVRFqcyN4TrrM+2dmFmKyTnrOyMTLczYyQ6Swio+WRtj5l4oOTWiYMEDQ+M4VVRFvs6NFe112dzNxCxMNF1lU77KE8j7nddBaRwTT+srGipibZH5vUMmmsqHoDgBsn814Gwgfs6JFez6lNZmYh4imseeZzkaHSIa0bTGcRGYrgA/MDyf7YpJUJA0RQkx1+RVrsaFuf5yxPVl4hEsUDcndGh9f0es5zALTpPCIjvbmxvOr6ZH5g0sqksXzxm8FYNYm3RvbbkcNSJCLTtNjRW16ywwc0uN90FpFxCET1yfzApJQJA4qI/nkSb4222NGWfs9dmcydIkSynPa85S9Ghi2bWe5HEXFGb2wuWzKZX+AnJSll0lRRczeAiZ3rYLhHnOieXs9J2s4QwoQo8+znIkPX93nuC5DDXiJ+SJO3OVkflvAyYYDA/ImJvu+EZz/X5Tprk7UjhDCMDtiRmw47kWYAF02HERmC6M1NweqkzFeY8DJpDla/CcDKibznjKefbXPsDcnYAUKkkm7XXb0jMhT2gFbTWURGsJixNRkflPiRCWNCo5Ih7T2/1x6+JRkbL0QqGmYueiY8VHlKuy9AHgssporwzmTcd5LQMtlVXrUOhLpYl3eYWxqi4TrIXFsiyzHYty8auanNsfcyeNh0HpHWLIDvTfSHJLRMlLI+FuuyDD6xMzo8VwPyLG0hLjvh2tc3RMJ9GjhiOotIY4y/2FlRUZTIj0hYmTSXL14K5rtj204MNETDEZt5XiI3Voh0NMi64unwUFWP6zwDwDadR6SlHKV9f5fID0hYmWjChxDb4Spute29g1pXJ3JDhUhnDLYOOtHbdtvhExroNJ1HpB8i+tvtwWDCjvwkpEx2V1XNBegvY1n2rPae7vJsOeEuRAzOeV7VM+HB+We1JyfnxUTNLYD/HYlaeULKxHXVXwPIG285h7nlpWj45kRtnBCZSAO5e6Lhmw470X3MOGM6j0gfRJSwQ11xL5PHAIuAcZ9FzIwzuyLhGRrwJ2rjhMhk3a6z4vnoEEdYN5nOItIEY1VTZXVCfoGPe5lUVNTcBaB8vE1qcSPHotALErFRQmQLm3nOC5HhujYnugPg86bziDSg8dFErDb+h7kYfz3eIhfYe6ZPHnAlRNyccJ11O6PhAZexz3QWkdqY8camysqyeK83rmWyI7gkCPBdYy2jgSO7I+F18d4QIbLdkNYLn4kMLm9zojuYcdZ0HpGiCD7t+f8m3quNa5n4iP967HXScFNk2NJATtx3kBACwKVRyvORIWvQ0ztNZxGpSRG/5zHAius647Wi7bjdR8x/NdYyIdfZOcC6KkH7RwhxmQ2evsseXtvuRHcy47TpPCK1MLAgWFZ9ezzXGbcymRYMvYGBUU+ou8wHDzmRuIYXQoztuOusfS4ylDOovUbTWURqURa/J67ri9eKGGMGi+y2I/54fp4QIjYOeNquaHj1Xie8XwMdpvOI1MBMb9lXtmxmvNYXlx/uTdXVcwB63Wjf79feiwPaW5yMHSSEGNkZ11v2THiwuN9zngHgmM4jjMuNUDRud8THpUzY5rdglJsPNeNYS1Su3hIiFWggd78dvW13NHLUZT5kOo8wjPCueK0qPmUC+vPRvrXPiZzXMUytIoRInnPaXfJsZGhJh2vLZcRZjIC1zeWLl8ZjXVMukx3BJUECRrw9f4i9HWc894Zk7yAhxPgYoGOOve7Z6FD+Oe02AvBMZxLJx0RxGZ1MuUws6HdjhKnmGbi4JxqpMLBvhBAT4DLn7o5GVu+MhE+Ftd5vOo9ILgbeznF4uu2Uy4SAt4/0ep/r7I4yF5vYOUKIiRtib/6L0eFlrW70IDPLvSnZo6Khonr5VFcypTLZVVG9AsAfHW9j5o5DTnStwZ0jhJikk45z7TORoem9rrMLQMR0HpF4CvS2qa9jCizQn4z0eqsTDcmz3IVIXx7gb3GiN+6KDJ8fZt5rOo9IsBgfsT6WqR3mYn7LK19ymfd0ee5NBneLECJOBlnP3xEZWtkUHT4eZX3AdB6RMEubKpcsm8oKJl0mjWXVlQyseOXrh92oa3qvCCHi64LW5c9Hhq/bZ0cOu0Cr6Twi/ljrt0zl/b7JvpEIf/rKB1A7jGZ5TolIY/0gdINhAxgAEKbL5ww0kENAPoCZAPIZyCegBFn2pNBTnrvkmfAgl/n8zy/yB8oUKO7PxRDGvBVA/WTfPOkyYeI3vvJqssNOhCe5OiGSqY2JdpLGXgIfU1DHhjh6rP7UqcGJrOTrWOW/MLcv6FpYbLFXrZkWE3AdCDcisx+zQCdc5+Zu17FrAjnPF1v+ZQCmmw4lpqx2V+WS6huPHZ7UyHNS1xY3BGvnE5xuXHWYzNZofC46KKMSkXoIe8D0PwrYoSze+fFQKKGXvX6xtDTPcXktg29njQ10qVwCpndDolhEF5b6AzuKLP96ANeYziMmjxgfqzve+sVJvXcyb2oKVv8lA/9x9Wsv2eHm0563yvTOEAKAx6DnFfTjmvjxLb29nSbDPFRUVODBeiOAPwPwWmTolY55Cr21/ry26cpananbmAX+Z3Vn6+sn88ZJlUljsPr7uOpmRQ/80tPhoRWTWZcQccPoItA3XO371idOH+8xHWck9bNmXZPny3kTE/0ZgFchA3/o+on6r/Xn7pltWetIRirpJuK4w7PWd3WFJ/rGCZcJA6opWN0PYPaV147Y9nNdnn2L6b0gstaTxPxIuL/n5/VA2lxN+FBRUYFmdSeD3gjCXQDmms4UT37Q6SWBnL1zLd9qknMqaYNI31nX0f7bCb9vom/YVVlTpzS//NQ2ZnRujwwu5Dg/T1iIcTABP2LSn97c29tiOkw8bJs/v5ah3qAYb2RgPeIwX1IqsIgGa3yB5hKffzlfuhpOpDBierju+JF7J/y+ib6hsbx6KwifvfL1Cdfd3uZENpjeASJ7EPBDxeoz9/Z37TOdJVEeKiqa57HvtUz8NgJejQy4OsxHNFThCzSX+fxLkWGjsAyzf3Vn64Tn6ppwmTQEq58k4I5LX/H5ZyLDlss8zfTWi6zQqUB/f19f9y9NB0mmB8vKZlLUfR0Bf8KXTuCn9SEjP+FitT9vT5Gyaokwx3Qe8UeY4S9Z09nSO5E3TahMWmprC4eHnDO4fJnjOe09tTsavsP0louMF2XCp2b1Fn/x/WjO6sfN1gMqp7j4ejBtJMZGALciTS87JkAX+XzNNf5Arg9qSlN5iPgi4K/qOlu/M8H3xK6xvPr1IPzqytcN0eEjA1rXmN5wkcmo0WL660w+pDUVD8yfP1exejWI7wTTawDMN51pMuZZvr3V/oCbQ2oVMuRcUZr7z9WdrX85kTdM7A544tuu/Dm7zHsGtL7e9BaLjKWZcP+i3u7775EnAI5qa2/vKQDfu/wfPFhUVAmojQq0kYE7kSaX5vZ77sp+z0U+UX9VIKdtrrJqAZphOle2oksj3om+J3aNFdXPg3ETALQ79tPHXft20xstMtI5AO/Z3Bf6mekg6eyhoqIChm+DB76TCK8Bo9p0plj5QOcr/P5dCy1/FREtMp0nG3k+vXBte3tXrMvHXCYttbWB4SHnPIA8Bi48Ex60PKDQ9AaLDEPY4yN+88d7eo6bjpJpPjO7dIHf8u5gog0ANgAIms40HiJyyixfU7nlL/QrOa+SVMxvXX287cexLh5zmTQFF9/IoJ0AcIG9p5si4dtNb6vILAT+dVi7fzbRCRfF5DxUVFThwtpAoA0A34FLsyCnrEJSHdX+wMlZlm+Z3K+SFF9a3dn60VgXjv2cCdPNV6rnmGPLH6SIKwI+d19fzxYCZObpJLm3r68DQAeAbwPAZ+eUFyufe7NibGTwa5BiI5dB1hW77UgFAG+e5du9yB+I5pNaA7lhOlFunsjCMY9MGoPVPwZwN8AnnwwPLcBUn9IoxMv4E5v7eh4wnUL8HgP0QFFRrQ/WHXzpkNhtSMHRQC6p9sW+wJG5lm8lERaYzpNhHLIHZ9SFQsOxLDyRMukGUHKWve17ImG5413ECf3j5r7uz5hOIcZWD6j8kpKV2uNbAFoPxnoQSk3nukIB0YX+QHO55S/0E0347m0xMia+bU1H27OxLBtTmeyuWFrusdcJALuj4QPntHed6Y0U6Y8Jn97SG6o3nUNMzraZldM5EFkNws106SrPmwDkmc5VoKg/6MvpmKesBYooZQovHRGwpa6zdVssy8Z0zkSzdz0AMPjEOe3Vmt5Akf4I+NxmKZK0tvncsQsAnrj8H9QDvpzi4hWkcTOTWgXmWwkoT3auIc3zWuzIvBYAMyyrJ2gFQrOUVUGEWab3WbphYG2sy8ZUJgysAIAzWrcDkGc+i6lh/tF9/T1bNpnOIeKqHnDR09MMoBm4dN7lwfnzlxKr9ZdHLutASOqMGec9r3ivFy4mkC5S1oFyvz9coKzrKAVGUGki5suxY72a63oA6HKctJ5gTqQAwh4L+q/kqq3MRwCjt/cggIMAvgUAD5eUzHE9rAOhjpjrGFQHYF6iszBY9Wr3ut6oCwXYRT5fQ7kvoAtI3YA0ndssSSp2VlVds7a9/eJ4C8Z0zqQxWH2MgVnbw0N5DJYdLyarDxbWbA6FTpgOIlLHtpKSMnK5TpOqI3AdgDok6cqxHFJDJT7r8HwrYOUTLUEGPvlyqpjVTWuOH35xvOXGLZMXS2tn+X3OmbDm51+MDk3oumMhrmKDsWFzf2jcv5RCfH7ewkUeeXVEqANzHUA3IMHzjCnAmWv59pX6AhenK7WU0nTSzHgj0P+p6zzyb+MtN+5hLr/PWw4AvdrO6qm/xVTR/Zv7u6VIREzu6z95FMBRAD8ALl2aHCgpqVYu1+HyCIaBlQAK4vWZGvD3ee6qPs8FAJ5Gan+FL9A/y2fNt0BZe+GRho7pvMm4ZULwljOIQ6632PRGiXRFjZG+7pguLxRiJPWARih0GMBhAI9efk3lzy1d5Fm8EqxXALSCgOWIz0VCNMB62T4nAjjANGV1lFm+E7Mt3xz/pcNhWXTXPcV0K8i4h7mayqu/4RFu3R4elOeWiMmIaNKrtl46EStEwj1YVjZT2d5KZr0coBVgrAChFnF69LGfcLHIFzgyX1nONWQFiVJ7TrM4OF/X2TprvItmxi2TxmD1M+e15zVH5a53MXFMuG9Lb+gh0zlEdqsHfP6ioiU+VisYtByElbh0y0PRVNedQ+rkAp/vaJHly8knWpqJz2GxyAre0HFozJm8YymT7nY3cvS4495ieoNE2jkY6QutqAdc00GEGMnn586dzypQC+IazVhKwBICahhYOJn1KcCbbfnaSyz/uelKzfMTVSADnhzJoNet6Tzym7GWGfOcyfM1NdMQ5ZI+V8sPAzFhRPTBeikSkcLuO3WqF0AvgCevfv3rWOU/W9S1kGDVMuFaxVQJcC1fOiczbbT1acA65bk1py6dxIcF8qZb1sl5ytc/U1mBfIVgOo5ciLhqvGXGLJOciFelobojrOWudzFRv9jU273ddAghJuP9aHbQh2MAjgH4xZXX6wFf/tzSClZ6KROWgFFDwFIGlmCEe2M8sHXWc4NnPTd4+SU9TVHbXMt3cp7yI1/RQgJVIfVHLxXjLTBmmZCyqqKe1wnI1M5iQmyl1cdMhxAi3uoBF6e62gC0Afj51d/7YmnprKjrLgKrSgWuBKiSgUoGFhFQiktXgKkBzYsHtLP4GC7dbZEH1TvP7+uYoyx3Gqk51qVDY6l18ySP/2ybMcuENS8+q13b9HaItPPofZf+wQmRNT7a1XUWwFkAja/8Xn1tbSC//0K5Jq8SUJWkeBEzKgFUhqErjzv2uitntwnkFlqqfZay+meR5UxTapqfKAgYnahyiiMTwuJT2pP5uMREMCl+2HQIIVJJfUuLjUujmRF/yXpg/vy5FluLGFzJ4LKLrrfwInllnUDZ5VHNrFyinhmW1TVbWcMzLF9ODlQJgRciOYfIKsdbYMwQjcHF25+NDK9wmFPuCWsiRRH9ZHNv91tMxxAik3wdq/zn5/TP1X63GKwqiXUJgYr9QEWhsmYWWlZuIVn+aQQrR9EMH9MCIsqPZwbH9c9e39VydrTvjzky8Yj8UiRiQjz+kukIQmSa96PZwWmEAIRweYr/V3qoqGieq9RC0lRKQPkMn1U4g61rplu+a3IVFQXA831klRJ4HiZxTiZHeRW4dBhvRGOWietpz/ROFGmlafOp0POmQwiRje7t6+sH0I9Ryga4dDVa3pyF8wpydGGxlTt3pkWzfRrzfKQWKk1FRHoeCMUEKrr8YDN15b2exYvGWveoZdJUWTn9lMtSJiJmBHzXdAYhxOjqARenT4Yuf9k61rK/KS2dNUPlzlcKcwE1H57XMtbyo5aJ66oF5z3Hb3rjRdpwFbz/Nh1CCBEfr/391WkxUaN9w7JowXmt5ZnJIiYM/PryMFsIkYVGLRNmLBhmL+GP0xSZgYDvm84ghDBn1DLxQDMdxhzTAUVacMizf2U6hBDCnFHLZIh1nulwIj0wY+em06cHTOcQQpgzaplc0J6UiYgJAU+YziCEMGvUMhnW3rSJrEhkLw36nekMQgizRi2TCPMM0+FEWhic3T+/yXQIIYRZo5+AZ77GdDiRFva9H82O6RBCCLNGLxPCDNPhRDrg/aYTCCHMG+M+E5ap58X4iKRMhBAjlwkDyoOMTEQMSEYmQohRyqS5pCTXYSkTMT6tVMvU1yKESHcjlsmA4yhXruYS4xvc2t19xnQIIYR5I5ZJZ0GBD2OcTxHislOmAwghUsPI50wiPpl6XsSATptOIIRIDSOWyXknEjAdTKQ+gpaRiRACwChlEvW7MjIR42KCjEyEEABGKRPLk8NcIgaszpmOIIRIDSOWiWvJyESMj6AHTWcQQqSGEctEsc8yHUykPh9ZMieXEALAKGVClrZNBxOpL1eBTGcQQqSGkUcmnidlIsaVD0vuRRJCABilTLQXiJoOJlJfjqIc0xmEEKlh5Ku5AjIyEePLB8mjnYUQAEYpk8FIRMpEjKtAWSWmMwghUsPIx7yvuUbKRIzLDyw0nUEIkRpGLJNPdXbKORMxLiLMfwyQy8iFEKNcGgwwALmHQIyJGVRaWj3fdA4hhHljXdopoxMxJib2cnzqOtM5hBDmjVUmEdPhRGrTTFqTt9x0DiGEeaOXCUOeoCfGxMweNC0znUMIYd7oZUJSJmJsrMBEkJGJEGLMw1xSJmJsTB4Dy5uqq+eYjiKEMGusMpEHH4kxecwMgHSUbzWdRQhh1qhlQoSzpsOJ1OZCX7p8nNRtprMIIcwatUyYZWQixhZhjgCAAm80nUUIYdboZSKHucQ4bMAGAAaubVy0VO43ESKLjXFpMMsJeDGmCHv65S88762m8wghzBm1TCw5zCXGEdV/8PdHykSILDZqmbh+OmU6nEhtDmv/VV/WNlfUyD0nQmQp32jfyFXquO1pBuQ532JkLiP36q8Z/H4Af2c6lxBi6lpqawPRYV3sebqULSywtN6/6njbodGWH7MothWV9ACQWWHFiBTQtiGvcPHLLzAGPb9esLa9/aLpbEKIkW3H7b7CslAZ+VACpmIwKjVQQuBiEErAKAZQArzil0Xmt6w53vaT0dbrG+dzOyFlIkbBwMw/eIFQ6PPUPQC+ZTqbENnqpaLlBXahU8HaqVCgoAaVg6kY4IXEKAaFSgHksgYuPW3kqlEFj7Fii06O9bljlgkBHQysNb1zRGpiYI7LGPARpr38GmPzdtz+HxvwtGs6nxCZaF/ZspkOnEq2uBKMSsal/w9CJYAFNiI58ACCwu/PU1xuiSmctPAp3Tnm98f6pgZ10phVJbLdIHT3DKglV720qCAYegs68QPT2YRIRwyohvKacmKuJKIgFCoIOshMFQCCUURLriz4ssSf2Q5f394+5hW+Y49MWB8Hyfl3MbqLnnt+hi/wB68RsJWBxwjym4gQo9ldVTXXs61qEGpAXA1gMYCaJqBKgXMuFQRf/j/jP4ePjffvecwyYVCH8U0QKe2ip+0R/hYtb6qoeQs6jvzIdD4hTGoqKcnXgYJqRWoxa10NUA0I1QCqPRczodLj9y1mPjzeMmOWicWqQ5Mebx0iiw3+4b0mv8f8+e3B4C83dHbKEztFxtu9sKbE8+laZnUtoGuIqBqMagZKCSBmRjof5dHAofGWGbNMhudNP557+pzG2FPViywWZT19lG9VTKOcewHcbzqjEPHAgGosq1qqLOtaZq4FcC0BtQxUeeAAmEBXTnmnx4AjZkTWwXGXGW+BB4tKOgkoN70xImWde1Ve4cxRvjdAbNXUHT/UYzqkEBPRVF09B1FapsFLQXwdQV0L8HUAZpvOZkJU0eqbjx1pGmuZ8e4zAYD9kDIRo5sZ1XwmR9FI/8imMdyvAHib6ZBCjKSltrZwaNBbrshbzkTXMWMpAcvYxlzQldPehIwbakyM16aj7eMtNG6ZEGgfwG8wvTUidZ1lr6MYvpF/YyN6a0NFzT1rOo48ZjqnyG4vllYv8FtYAWAlCCsJvHJ4yFlEBMWXD02l71mNxHGhj76ns/P8eMuNPzIhvJTdpSzGc8pzhout0f8qEfMjuxfWPH/DySMh01lF5tuO230FZV01IGslAStAvBLASgBzr14uBS63TQsRjf2xLDf+yIT0fmbZ6WJ0F5nzx1lktmfxT1tqa2+pbWmxTecVmaMhWDsfFF1NrFYxYxURrgWHykDKl+WHpuJmmL1xr+QCYiiTip6e1mNFJcMAxvuBIbJUVOvFAMabYXrN8JB9P4BNpvOK9NRUUpLPvmnXs0KdIr2ameoApxqsCLjqylv53TeuBshri2W5ccvkHsDbBhwEUGd6o0TKmj7E+kQBqbKxF6N7d5VX77zxeOtPTQcWqa1p1So/nRpazspbzUR1YKxmxrUg9hEAOVqSHAy2+2097g2LQGxXcwHAPkiZiDGcdp2uAn/OOGUCUoTvNQerNqzqbN9pOrNIDduDwdxpKlCnNa0i5lVEWMVnBmpYwfqDezakP5LuouYjZ5U+EMuyMZUJgw7IhI9iLGe0dmO8fjxXQz3WVL70Rrn/JDvtKq+pUKTXgqiOGauJcT1rFNLly6nkJ03qCGvdWh8KDceybExlooB98gcsxjKgec4EFl8I8v7nxdLaO9Z3tZw1nV0kzvZgMLdQ56xiS69TTOsZWAfwfFx9Ka6MOFLWxRhPvgOxHubyog2wAh4Ay/TGidTkQi+Jaj6doyimUmFghd/nbN+1YMkdN3YfPmM6v5g6BqixrOpastRN0LiZCKsYqIFii1iObaQbBpw+zzkW6/Ixlcmm06cHthWV7Mela7WFGInq8Zy2oApMZISyXPn5F3uCwddfH8NNUSK1NK1a5dfnBlYqzesYtK4JtJ7AZRk6PVXWuaC9Iw5TnEcmAMB4ASRlIkbXp10OIjDBd/E6FzlP7q6qeu0N7e2nTG+DGF1TdfUcdmg9M68jYD2fGawjIP/3N/9JfWSSXtftC+f598a6fMxlQuAdDPo70xsoUtdQbPebjIBv8Fz1zM6qqtesbW/vMr0d4pKdVVWlPoduZcItBLqVbSwF+KqJ1KU8MtkF6DP1nSdjfoREzGWiSL/oySkTMQYG5l5g78h0smom8fallqsamoNVd8tlw2Y0VtTUQONmEN8K4Ba4qLhyO4fURnbxGINDnjuh6Y9iLpN7+/o6ts0r6QKh1PSGitTV5Th90wOTKhMAKNZQ2xsrqt+/uqP1P01vSyZjQDVUVC+zwLcy0y0AbgHzfLmySgBAj2vvB+O5ibwn9nMmAEB4EcA9pjdUpK4z2ps5xVXkgvGdxmD1G3yw3ycn5uOjqbJyumZ1K7G6CYSbm5iuV8z5MtmhGEmX5zr+gPX0RN4zoTK5fN5EykSMymFeOsbzTSbibS4C1zYuWvr21UcPxXQHrvi97bjdl1/etVqB7oCiDaxpHeHyhJz88n8J8UcYbA9rbW3qCk3oHrAJlYlWeE4eCS/G4et0owdrArm3xGFdtXC9PQ3BmkdywjlbV/TtGzK9camqraoq57xWt0BjIwgboUMrLs2cCykPMSH9nrdXE5on+r4JlcmsnpJ954p6LgK4xvQGi9TVp72Zkz1p8kcIPgJ/yMmLbGyuqP7bVR2tEzqOm6kYoKZFS2vJc+9g0IbzLm4DMPPKN+XolZisk649DOZnJ/q+Cf+V21ZU8hMAbza9wSKl8bqc/J58pUrivV4Gfd91+b71Xa3dpjcy2XZVLqlW2tsA0AYGNhAwz3QmkWEY7pPhwVM+H5Z/PBQ6PZG3TuwEPAACfsVSJmJs1OHax2oDufEuEyLwO/0W/qQxWP1wjs75yvIT+8+Z3thE2b2wpsTz8UZobCTCHaz1Alz1VHIh4q1Hu7tBCEy0SIBJlIlj4bc+z/Qmi1R3yvOKE7ZyQiGA+qiKfrQhWP2IJufLazs6+kxv81S11NYWhgft25iwEaBXe+BamZpEJFOn69gAvTiZ907qF5wHi0peImC56Q0Xqa0uJ+/odGUtSsJHaWb8miz8S92x1ifT5WfvH500Z1wPQJnOJbKTyzj9TGSwkIhev6m3e/tE3z/hkQkAKMb/MkmZiLF1OnbPipy8ZJSJIsIboPGGpvLqpgaiRxWrx1LxeSnNixZVsac2MujV511swNUnzYUw6LgbPQDg+hm9858HJn5KclIjk8/Pn3+bZvW06Y0XKY5x4fb8wnwL8Bv4dA+Ep5npF0T4zeqOI0dM7IJdC5bMtgJ8BzNvBPBqABUmcggxnqcjQwc85gOb+0LvmMz7JzUyGZ49e0fu6XMDAKaZ3gEihRGmdznOznK/f62BT7fAeBWBXwUGmoLVnQzaDuhdDOwa6lxwYAOeduP9oU3lS4s9eGst4tsAup2hlzHLoSuR2gbYO+Ix1xLz5ye7jklfFLJt/oIfg/lu0ztBpDYL1HZ7XsFi0zlGECHgCAOtzHSEgA6C7iO2eqNa9xaqnGFrmh6qbWmxr7xhZ1XVNfl2nmVzeBb8qlhrLCBQMZgXgVCLS+cRp3rnvxBJ1xgNP3dRe+s4xzdvy4kTk7pCcvJlUlT8NwB9w/ROEKnvhpz8lplK1ZrOIYT4Yw5w6tnwYD4Iezb3hiY9c8Wkh9+c4/8RAHuy7xfZ44gduWg6gxBiZG1OdD+AAmj8bCrrmXSZXB4KPW16R4jUN8T6ehssT1EUIsUw4PS57iIA0Er/eirrmtKJQQIeM70zRFrIPerYB02HEEL8oZDrNGlwOYCWrb29U/o3OqUyCUQDPwYQNb1DROoLuc4yl1lm/RUidXCbG73y/KFHp7qyKZXJR853ngfwW9N7RKSFWW2u3WQ6hBDikl7XafAYSwAwLHxvquub+vXvzHKoS8Qk5DrLXC2jEyFSQatr51/+nzs2h0Inprq+KZcJaednAMKmd4xIC7PaPBmdCGHaac9rdpiXAQARvh+PdU65TDadPj0A4DeG941IEz2XRieDpnMIkc0OOy+f6nY96B/EY53xmubhR0b2iEg7DMxq85wJPxJUCBEfZ1x3b5T1qstfPr21tzcul+3HpUwic2b+CIDcRyBi0uPaMjoRwgx9wIm8PPEqEU35Kq4r4lIm9S0tNiM+x91E5mNg1mHHltGJEEl20nF2uMCVqY2GOJrzeLzWHbfZTNnCv0GeyiBi1KedG8Nad5nOIUS2YCDS5tjlV74m0H9tPnfsQrzWH7cy2RoKHSZgUo97FFkpd48dljIRIklabXsHE5de+VorHdeJeuP6nAUNfDtZO0akvzDzjac9d7/pHEJkOgc42+XZVz8dd++Wnp64HmqOa5nk+NX3AUxqLnyRleiAHc1j5rg/pEoI8Xt7osMH8AfP2uFH4v0ZcS2Tj3Z1hcFTvy1fZA8PXHXUcXaYziFEpjrtebsHtL76OSUXI9qN+wVTcX+cKFv87wndMyLjnPDspS5DnnkiRLwx3P12OA9XPQiRgMfqT52K+6X5cS+Ty8fhZMoMETMG5uy2w3tM5xAi0xxxo89oYOnVr2mK74n3K+JeJgDAwBcTsV6RuQa0d2uv5+42nUOITBHR3NPl2qv/8FVq3NLb25iIz0tImSzqCz0G4Ggi1i0yFh20w6U2+LzpIEJkAN1gD/UAdM3VLxLrbYn6wISUyT2AR8BXEhVaZCYGzdsTHW4xnUOIdNfmRJ91GDe88uVwf8/jifrMhJTJpRV7/w/AmUStX2SmQc039XiuTLUixCQNat1xwnXWvPJ1ZvpiPaAT9bkJK5N7+/qGAHwzUesXmeuQHV4oh7uEmBSv2Q4PAch/xeu90Xz/fyTygxNWJgDgWngEgJPIzxCZh0Hz9kYjB0znECLdHLKjz7rM173ydSZ8s76zM5LIz05omXwyFDoJYplNWEzYgPZubneiz5vOIUS6OO25u0Oec8sI3xrK8akvJ/rzE1omAAC2HobMJiwm4bjr1J1nfdh0DiFSnQPd/1I0UgzA98rvMeM7H+3qOpvoDAkvk819XfuJ8L+J/hyRkXJ3R4ZzXGa5O16I0eldkfBREIpH+J4LVl9KRojEj0wAkMInIKMTMQkMVOyMDh+G/P0RYkQHnegzUeZ1I32PQN/ecqqrPRk5klIm94VCuxn4VTI+S2SeKPOaVtt+znQOIVLNGc99qcd1bhrl27Ym78FkZUlKmQCAZeFTkN8uxSSd9Oy1Z7UnNzQKcdkw6+6X7EgJgMBI3yfib2/p7e1MVp6klcl9odBuAD9M1ueJjBPYGw0XD2uv03QQIUxzGRd3RcIRBuaOssiw6wb+OZmZklYmAKBJfxqAl8zPFJmDgVk77bCymWVmBZHNvJ3R4SMavGjUJYi/9onTx3uSGSqpZbK1t/cggB8n8zNFZmFGWUN0+Diz3AwrstN+O/pslPXqMRYJe27g4WTnSmqZAAAproeMTsQURJlvaIgOPw85ByeyTJsTfaLfc24faxkiPJLsUQlgoEw29fQcYiJ5tK+YkkHWG1rsyFOmcwiRLF2O/eIJ19mAq56aOIJznkVJu4LrakkvEwBQFrYCGDLx2SJz9HruHSdc+0XTOYRItH7P3X/EtVcBsMZajkH3b+3uNnJO0Zr6KibuiYGBixsLp2kAG018vsgYdFZ7JRZh5wxlLTQdRohEOKPdI/vsSAWA3HEWbYn2hd77dAKnmR+LkZEJAAT86l8YOG7q80XGsNode1WP5zaZDiJEvA1or3NvNDIPQN54yxLjk/WAayqrsTL5aFdXWDH+wdTni4ySc9COrOhxnQbTQYSIl/Paa2+IhmcCmBnD4r/d1B963GReY2UCAJv6Q49DJoEU8eE/6ERX9nhuo+kgQkzVee0dbY6G5wKYHsPirib9EdOZjZYJAGjoj0IeoCXiI3DQjizv085e00GEmKyLnm5vjoZnILYiAYG+ffkePqOMl8nW3t6DBPp30zlExsg5EI1Wnfb0S6aDCDFRg6yPNtpD0wDMjvEtA/DUp03nBlKgTADAI++TAM6ZziEyRuFL9vCSE64t96GItHHG8xobIsMzASqK9T0EfHLT6ZMh09mBFCmTrb29p4jI+DE/kVFy2hx7w34n/IzpIEKM56Tr7Nxrh5czMCvW9xDwQrgv9FXT2a8wcp/JSJ4YHHhpY+G09QAWTXllQlxCQ5qD57T3bLHPv5DGvnNYCCOO2fazR117LQD/BN7mePDe+E9DQ32m81+REiOTl8No9UEAYdM5RGY5r71bG6LDO2VySJFqDkftpzs8+2ZM9Bd7wr98oq/vgOn8V0uZkQkA/G744tlXTZvmktwZL+LMZl7Y7TkvLbAChYqQYzqPyG4asBuj4R2ntXsrJj5i7rTg3fO7oaGU+uUopcoEAG4ZHNjhL5z2GgAyPYaIKw8oPunYZ2ZYVlceqblTX6MQExfRCL0QGeqKsK6bxNuZSd29qa+nzfR2vFJKHeYCgHpAa8V/D4PTAojMpQklu6Ph0pOOvd10FpF9Lmqv5cXokOuBr5vM+wl4bEtv19Omt2MkKTcyAYAnBwd7Nk6bdg2A9aaziIyUc0Z7wUHtPVvk8y9ECv5SJTLPSdfZccCOLGZg3iRX0adJv/HJwcFh09sykpT9RxRR+BSAdtM5RMaiU9q77dnI4B4but90GJG5PMZgoz38VKsTXcfAtEmuhhXor7f29p4yvT2jSelLJT9XtGAtg58D4DOdRWQuYuq6IS93YAZZS01nEZllUOuORnvY1oyaqa2Jv765r+dvTW/PWFLyMNcVTwwNdG0smEYgbDCdRWQwwjU9rjtjWPPzcy2rlIhSdsQu0keHE33hgBOtZKBkiqtqs6DvTrWrt14ppUcmAFAPqNyikt8BuMN0FpH5LFD7DYFcfY1lVZvOItJTlLmvIRo+aU/uaq1XspWFdfeFQrtNb9d4Uv43sHpAu656N4CzprOIzOeBqxrtcNlBJ/oMG3pinUhf3a6z6/nIkBWnIgFA96dDkQApfpjriqfCFwc2FhSGQHS36SwiK/gGtQ52u25jkeUnH036pKnIEhoYaI6Gn+32nFsAFMRnrdQ4s2/+e3+JnrT4pSYtygQAnhga3Pfqwmk1AJaZziKygwde0OXZDkC7Z1rWQqTBYWGRfP2e19xgDyPCvArx+ztygbW68x+Gj5w2vX2xSqt/HPVz5xbmKv9uAItNZxHZxQIOL8/J82Ypq9Z0FpEawlqfbLbDvVHm1XFeNYPojZt7u39lehsnIq3KBAAemFdykyJsx8Rm2BQiHtzpSj25MpBX5yOK9eFFIsMwI3LIsZ/t8ex1mPx9I2OgL2/u6067R3KkzWGuK54cGjj56sJpFwC8znQWkXVUlLnquGsP+In2T1eWzB+XZfo8t6kpGo5eZG8NkJAJQ3fO7Ct+Z7qcJ7la2o1MrthWVPJfAN5pOofIXgHQ3pU5uYXTlFVlOotIrEHWR1+Khs9G4n9I62pnXAvXfzIUOml6eycjbcukPhjMzQ3bzwGI0yV4QkxOgGj3spy8/BmklpjOIuJrmHX3vmj4xBDzjUjsrRQeEb16U2932k5AmrZlAgAPzi2tIqUbAcwwnUVkPa9AWTuXBXIWFpAqMx1GTI0LnD3khPf1u+4NAF2T6M9j8Ge39PV80vR2T0ValwkAPFhUspGA3yANz/+IjKQLiHZdl5M3v5BUhekwYmIizKH9duToRZ2wcyIjeWxTX+jtBLDp7Z+KtP8B/OTQwLGNhYV+gG41nUUIAOQAC7tdp/CM9l6cblk6QDTTdCgxtghzaJ8d2d3qRBdFmauQvMllD0acyJs2hMNR0/tgqtJ+ZAJcmr8rb37Jr5jxWtNZhHgF9hPtqvLlhIst3y1EMgN2CuHTnvdCqxNxwsw3I/m3G5xRbN14X//Jo6Z3RDxkRJkAQH1JSX6uh6cA3Gg6ixAjIXDfXJ/vcI0vd1mAaJbpPNlKA+Fjtt3Upe0ij2FqQs8oGHds7g+9aHp/xEvGlAkAfKakZKHPww4AC0xnEWIMgzOUtXtJIKe0gFSl6TDZYkjr48e8aEe/49WAUGwyCzN9YEt/99dM75N4yqgyAYAH5s+/VrF6HoAcpxYpT4GOzvGprkW+nIp8uQos7hzw2WN29ECP5831wCnx8DMifGFTb+jjpnPEfbtMB0iEbfPnvw6sfg55QqNIH14uqb0llj+y0PKt9CmK08yz2YcBp9dzXzrpRiMDmlcCKDSd6Sq/jfSF7qoHXNNB4i0jywQAHiwqfh+Bvm46hxCTEM4n2lvmC1hFlq/WR1Is49GA1+s6B05qJzLoeUuTcW/IJDSRZ9+x6fTpAdNBEiFjywQAPldUso2BTaZzCDEFjh90cI5PnS+2AvNmKKuG0uChdskQZj7T4zlH+zzXCmu9hOP2HJGEaLPg3XxvX1+/6SCJktFlwgB9rqjkewDebjqLEPFAwNl8oiPzLJ9X7AssyiMyeiI5mTRo+Ix2WkOOc/Gc1gs88CLTmWLUy/Bu2tLXd8x0kETK6DIBgPra2kDe6bM/ZdDrTWcRIu6YugsUdc2yLJ5r+YqnK6s8E4YtDOhB1h2nXa/njHb0IOt5HiOZNxPGywWl6fb7TnXvNR0k0TK+TADgi6WlebajfwVgg+ksQiSY4yPqKFB0eiZZPNvyzSxUVrEvha9udBkXz3tu5zmtz19gF0PMMzzmCk7Is0KSKkpEr0vnyRsnIivKBHj5KY2/A7DWdBYhko0Y54moJ49wPpeUXWhZqoBUbiGpmXlKzU5k2bjMsBlnh7XXPwh9YUBrZ1hry2bOcxhzmLjU9P5JAE1Ef7apt/tHpoMkS9aUCQB8aUZwRjTH3g5gpeksQqQYDeC8Ai4ooiELCPuBqCLFFqAVAEuBLaiXf2YwNDv60s8QB1AEsE2c43mc64ELNHANA9ORvAkTU4Umovdu6u3+jukgyZRVZQJcLpSA/SQIN5jOIoTIOC6I/nxzb/djpoMkWyacq5uQj5zvPK+Vfi2AQ6azCCEyStYWCZCFZQIAW3t7T1nw7gJwwnQWIURGYDB/MFuLBMjSMgGAe/v6OpR2bgSw33QWIURa00z03s39PVk940bWlgkA3HfqVG/Ar24HuMF0FiFEWtIM/M2W3u7/MB3EtKw7AT+Sh0tK5rgefgNgleksQoi04QH8gc19Pd80HSQVSJlc9lBRUYEH63EAG01nEUKkvGEQ3bO5t/tXpoOkiqw+zHW1e/v6hvKn5b8BwM9MZxFCpLQzRGqDFMkfkjK5yofa26OROTPvAXPW3LUqhJgARpcmfeum3i45z/oKcphrBF/HKv+5op6vAXiv6SxCiJTRqbR6zX2nutpMB0lFUiZj+FzRgk8w+H7IfhIi2+0nz3rtptMnQ6aDpCr5ITmOB+cVv5mIHgWQbzqLEMKIn1nw/vzevr4h00FSmZRJDD43v3QNs/45gCLTWYQQycOET2/uDX2aADadJdVJmcTooaKiCg/WrwAsNZ1FCJFwDgEf2NQX+n+mg6QLuZorRvf29XVwju8mAFnxoBshsth5Bl4vRTIxlukA6eTJCxciN8+d/QPL8RYSyTNRhMg0BJwE051b+kM7TGdJN3KYa5K2zVvwARB/GUDAdBYhxNQRsMP1/G/5xOnjPaazpCMpkyn4/NwFK7XinwCoMJ1FCDFpmgn3L+oN3X8P4JkOk66kTKbogQULZiuP/wuMO01nEUJM2DkFevd9fd2/NB0k3UmZxAEDtG1+yX3EeAByUYMQaYIafUq/7eM9PcdNJ8kEUiZxtK2o5O0AvgWgwHQWIcToCPh+WDvvqz91atB0lkwhZRJnD5SULFEu/guEG0xnEUL8kSgRPr6pN/RV00EyjVwaHGdPDgycvnlo4NvWtGnDBNwG2cdCpAbGbu3Da7b0hH5tOkomkpFJAj1QVHqjgv4vAItMZxEii3lM+Ey0N/SZesA1HSZTSZkkWP2sWdfkBPK+SszvMp1FiOxDxzTjL7b2d8tNiAkmZZIkD85f8DZi/jqAmaazCJEd6FHYOR/cfO7YBdNJsoGUSRI9MGdBtbL43wGsN51FiAw2yOCPbenr+YbpINlEysSAy6OURwDMMZ1FiEzCRN+1PPu++06d6jWdJdtImRjy2XnzipTyPyTnUoSYOgJOEuj/yJ3s5kiZGLZt/oK7cGmUUmY6ixBpSDPwVbJz/0nOjZglZZICHioqKtCw/pGBj0PuSxEiVoc042+29odeMB1ESJmklAeLFtxB4K9CnuYoxFiiBHw5bOGf60OhYdNhxCVSJimmHlC58xb8BYg/D3nmvBBXYyZ61HNoyyfPdHWbDiP+kJRJivrSjOAMO8fezMA/AMgxnUcIkwjYoUl/eEtvb6PpLGJkUiYp7oE5C6rJ4i8Q8AbTWYQwoBdMmzb1d3+XADYdRoxOyiRNPDiv+C1E9DCAoOksQiSBzcDXcvzq0x/t6jprOowYn5RJGqkPBnNzhp2/I+L7AMwznUeIBHDBeJSV/vSW3t5O02FE7KRM0lB9bW0g5/TZvyLQpwCUmM4jRBy4BPo2W/zZzaHQCdNhxMRJmaSxq0qlHkCx6TxCTILHRN9jxQ9sDYUOmw4jJk/KJAPUz5p1TZ4v78NM/BHIrMQiffxWQ/3T1r6uXaaDiKmTMskgX5oRnGEH7A8z4YOQSSRFatIg+imR3rapp6fJdBgRP1ImGai+tjaQe+r824lwL4OvM51HCADDDHzLr/iLH+/pOW46jIg/KZMMt21uyc2ssImAuyB/3iL5zjHhKwz9f7f29p4yHUYkjvxwyRLb5pWsB+HjAN4EQJnOIzJeNxjf8PnwyMdDodOmw4jEkzLJMp+fW7pYK/33AN4FYIbpPCKjMIAnifnfwv09P68HXNOBRPJImWSp+traQM6Z828C87sJeB1k6nsxWYwuVviqcq3vbjp9MmQ6jjBDykTggfnzr1VsvQ/gdwGYZTqPSBu7iPB1v0/990e7usKmwwizpEzEy+qDwdzc4ehbGfQ+ItxiOo9IQYRW0vgesfrefae62kzHEalDykSM6OGSkjmOx3cr0LsZWAc5aZ/NjjLhUYZ+bGtv70HTYURqkjIR43pwbmkVKe8egO4BsMJ0HpEUZ8H4OQHfq+gPPXUP4JkOJFKblImYkM+UlCz0eXw3gd7GwHrI36FMcpgJPwDxL6I9PXvqAW06kEgf8oNATNrn55YuZkvfyYzXAtgAIN90JjFhhwE8TqR+el9vV6M8gEpMlpSJiIuvVFXlDA0M36IIrwXTnTKNS8oaIPBzzLSdLP7Vpp6eQ6YDicwgZSIS4nMLFpTC5TsBvJqBWyDPXTElDOAFgLdrVtvt/u7GermZUCSAlIlIioeKiio8VjeRwk1gdTODr4VcIZYI5wE0MGEHET+VX1Cw60Pt7VHToUTmkzIRRjxYVjaTbG89M24i5ptAuB7ANNO50owD0F4G71LMDfBRw32hUKuc9xAmSJmIlMAAbSsqqgCrFQRaBkXLwbwCQCVkBAMAZ5nRoogOMfgAgRrzpuXtkVGHSBVSJiKlPVRUVODAf52CtxxQtQBXMlBOQDmA6abzJUAfwIdAdAhACzMd0uy0fKK/v890MCHGImUi0taXZgRnRANOORGXAwgyOAhS5WBeAGAegLkACk3nvEoUwEkAJ5hxEgqdYJwAcEJZOBkOBI7Xd3ZGTIcUYjKkTERGqw8Gc/McZw7ZmKNJFxEwhwlzAMwB0Wxispg5QIQCAGDCNWBYDPIT+A+KiIAIA2EQPGJcvPzyBYA0A2FiPgfCOWY6D+Jz0DgHS59zHd95N0efqw+Fhk3vDyGEEEIIIYQQQgghhBCj+v8BG2H4AjGi4P8AAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDMtMDZUMTg6NDU6NDErMDE6MDAvqBq0AAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTAzLTA2VDE4OjQ1OjQxKzAxOjAwXvWiCAAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          - operatorgroups
+          verbs:
+          - get
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - operator.tekton.dev
+          resources:
+          - config
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          - clusterserviceversions
+          - installplans
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - org.eclipse.che
+          resources:
+          - checlusters
+          verbs:
+          - get
+          - create
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - create
+          - list
+          - watch
+        - apiGroups:
+          - toolchain.openshift.dev
+          resources:
+          - cheinstallations/finalizers
+          - tektoninstallations/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - toolchain.openshift.dev
+          resources:
+          - cheinstallations
+          - tektoninstallations
+          - cheinstallations/status
+          - tektoninstallations/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - toolchain-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        serviceAccountName: toolchain-operator
+      deployments:
+      - name: toolchain-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: toolchain-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: toolchain-operator
+            spec:
+              containers:
+              - command:
+                - toolchain-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: toolchain-operator
+                image: quay.io/codeready-toolchain/toolchain-operator@sha256:3106578a6437854cb1bd59ae212e1e2a58ffd9b70cad2fe2f91efd79d3b6fa17
+                imagePullPolicy: Always
+                name: toolchain-operator
+                resources: {}
+              serviceAccountName: toolchain-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - ""
+  links:
+  - name: CodeReady Toolchain Operator GitHub Repository
+    url: https://github.com/codeready-toolchain/toolchain-operator
+  maintainers:
+  - email: crtoolchain-dev@redhat.com
+    name: Red Hat, Inc.
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc.
+  replaces: codeready-toolchain-operator.v0.1.2
+  version: 0.1.3

--- a/manifests/0.1.3/toolchain_v1alpha1_cheinstallation_crd.yaml
+++ b/manifests/0.1.3/toolchain_v1alpha1_cheinstallation_crd.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: cheinstallations.toolchain.openshift.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="CheReady")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="CheReady")].reason
+    name: Reason
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="CheReady")].message
+    name: Message
+    priority: 1
+    type: string
+  group: toolchain.openshift.dev
+  names:
+    kind: CheInstallation
+    listKind: CheInstallationList
+    plural: cheinstallations
+    singular: cheinstallation
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CheInstallation defines how CodeReady Workspaces (Che) operator
+        should be installed
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CheInstallationSpec defines the desired state of CheInstallation
+          properties:
+            cheOperatorSpec:
+              description: The configuration required for Che operator
+              properties:
+                namespace:
+                  description: The namespace where the CodeReady Workspaces operator
+                    will be installed
+                  type: string
+              required:
+              - namespace
+              type: object
+          required:
+          - cheOperatorSpec
+          type: object
+        status:
+          description: CheInstallationStatus defines the observed state of CheInstallation
+          properties:
+            cheServerURL:
+              description: Route to access CodeReady Workspaces
+              type: string
+            conditions:
+              description: 'Last known condition of the CodeReady Workspaces  operator
+                installation. Supported condition types: CheReady'
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+          type: object
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/0.1.3/toolchain_v1alpha1_tektoninstallation_crd.yaml
+++ b/manifests/0.1.3/toolchain_v1alpha1_tektoninstallation_crd.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: tektoninstallations.toolchain.openshift.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="TektonReady")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="TektonReady")].reason
+    name: Reason
+    type: string
+  group: toolchain.openshift.dev
+  names:
+    kind: TektonInstallation
+    listKind: TektonInstallationList
+    plural: tektoninstallations
+    singular: tektoninstallation
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: TektonInstallation defines how OpenShift Pipelines (Tekton) operator
+        should be installed
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TektonInstallationSpec defines the desired state of TektonInstallation
+          type: object
+        status:
+          description: TektonInstallationStatus defines the observed state of TektonInstallation
+          properties:
+            conditions:
+              description: 'Last known condition of the OpenShift Pipelines operator
+                installation. Supported condition types: TektonReady'
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+          type: object
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/codeready-toolchain-operator.package.yaml
+++ b/manifests/codeready-toolchain-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: codeready-toolchain-operator.v0.1.2
+- currentCSV: codeready-toolchain-operator.v0.1.3
   name: alpha
 defaultChannel: alpha
 packageName: codeready-toolchain-operator


### PR DESCRIPTION
Update toolchain operator to v0.1.3

Also added a few more bits of info to the instructions around testing with OperatorSource.

I haven't successfully tested with OperatorSource yet but I re-tested it 3 different times via catalog source + configmap:
1. created subscription manually with v0.1.3 starting version
1. created subscription manually with v0.1.0 starting version
1. created subscription via OperatorHub UI